### PR TITLE
Clarify OAuth comment wording

### DIFF
--- a/src/slack_clacks/auth/constants.py
+++ b/src/slack_clacks/auth/constants.py
@@ -2,6 +2,9 @@ OAUTH_PORT = 51403
 REDIRECT_URI = f"https://127.0.0.1:{OAUTH_PORT}/callback"
 
 CLIENT_ID = "9938573476978.9935591662693"
+# Mirrors the GitHub CLI localhost OAuth flow implementation
+# (https://github.com/cli/cli/blob/d3fb77f096677f9f5572f882f3ed5b3aa882386e/internal/authflow/flow.go)
+# so `clacks` and `gh` share the same client secret and redirect mechanics.
 CLIENT_SECRET = "cd914f918c2e8b802ebfbd4625e6dde6"
 
 DEFAULT_USER_SCOPES = [


### PR DESCRIPTION
## Summary
- tweak the comment near `CLIENT_SECRET` to refer to the CLI as `clacks`, matching the requested notation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c40d05acc8322b12b8b5f6b3a201c)