### PR TITLE
Add clacks config contexts and switch commands

### DIFF
--- a/src/slack_clacks/configuration/cli.py
+++ b/src/slack_clacks/configuration/cli.py
@@ -59,6 +59,7 @@ def handle_info(args: argparse.Namespace) -> None:
 
 def handle_contexts(args: argparse.Namespace) -> None:
     try:
+        ensure_db_updated(config_dir=args.config_dir)
         with get_session(args.config_dir) as session:
             contexts = list_contexts(session, limit=args.limit, offset=args.offset)
             current = get_current_context(session)
@@ -80,6 +81,7 @@ def handle_contexts(args: argparse.Namespace) -> None:
 
 def handle_switch(args: argparse.Namespace) -> None:
     try:
+        ensure_db_updated(config_dir=args.config_dir)
         with get_session(args.config_dir) as session:
             from slack_clacks.configuration.database import get_context
 

--- a/src/slack_clacks/configuration/database.py
+++ b/src/slack_clacks/configuration/database.py
@@ -174,4 +174,6 @@ def set_current_context(session: Session, context_name: str) -> CurrentContext:
 
 def list_contexts(session: Session, limit: int, offset: int) -> list[Context]:
     """List contexts with pagination."""
-    return session.query(Context).limit(limit).offset(offset).all()
+    return (
+        session.query(Context).order_by(Context.name).limit(limit).offset(offset).all()
+    )


### PR DESCRIPTION
## Summary
- Add `clacks config contexts` command to list all contexts with pagination (--limit default 100, --offset default 0)
- Add `clacks config switch` command to switch current context (requires --context/-C flag)
- Both commands support --config-dir/-D flag
- Current context marked with `*` in contexts listing
- Add `list_contexts()` helper to database.py for paginated queries