### PR TITLE
Implement clacks read and recent commands

### DIFF
--- a/src/slack_clacks/cli.py
+++ b/src/slack_clacks/cli.py
@@ -2,7 +2,11 @@ import argparse
 
 from slack_clacks.auth.cli import generate_cli as generate_auth_cli
 from slack_clacks.configuration.cli import generate_cli as generate_config_cli
-from slack_clacks.messaging.cli import generate_send_parser
+from slack_clacks.messaging.cli import (
+    generate_read_parser,
+    generate_recent_parser,
+    generate_send_parser,
+)
 
 
 def generate_cli() -> argparse.ArgumentParser:
@@ -31,6 +35,22 @@ def generate_cli() -> argparse.ArgumentParser:
         parents=[send_parser],
         add_help=False,
         help=send_parser.description,
+    )
+
+    read_parser = generate_read_parser()
+    subparsers.add_parser(
+        "read",
+        parents=[read_parser],
+        add_help=False,
+        help=read_parser.description,
+    )
+
+    recent_parser = generate_recent_parser()
+    subparsers.add_parser(
+        "recent",
+        parents=[recent_parser],
+        add_help=False,
+        help=recent_parser.description,
     )
 
     return parser


### PR DESCRIPTION
## Summary
- Implemented `clacks read` command for reading messages from channels, DMs, and threads
- Implemented `clacks recent` command for showing recent messages across all conversations

## Changes

### clacks read
- Read messages from channels using `--channel` (accepts channel ID or name)
- Read DMs using `--user` (accepts user ID, username, or email)
- Read thread replies using `--thread` with message timestamp
- Read specific message using `--message` with message timestamp
- Configurable message limit with `--limit` (default: 20)
- Outputs JSON to stdout or specified file via `-o`

### clacks recent
- Fetches most recent message from each of user's conversations
- Sorts all messages by timestamp and returns most recent
- Configurable limit with `--limit` (default: 20)
- Outputs JSON array of messages with channel context

Fixes #1