### PR TITLE
Add app_type to clacks config info output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.3.1"
+version = "0.3.2"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/configuration/cli.py
+++ b/src/slack_clacks/configuration/cli.py
@@ -36,6 +36,7 @@ def handle_info(args: argparse.Namespace) -> None:
         "current_context": None,
         "user_id": None,
         "workspace_id": None,
+        "app_type": None,
     }
 
     try:
@@ -53,7 +54,8 @@ def handle_info(args: argparse.Namespace) -> None:
 
                 context_result = session.execute(
                     text(
-                        "SELECT user_id, workspace_id FROM contexts WHERE name = :name"
+                        "SELECT user_id, workspace_id, app_type "
+                        "FROM contexts WHERE name = :name"
                     ),
                     {"name": current_context},
                 ).fetchone()
@@ -61,6 +63,7 @@ def handle_info(args: argparse.Namespace) -> None:
                 if context_result:
                     output["user_id"] = context_result[0]
                     output["workspace_id"] = context_result[1]
+                    output["app_type"] = context_result[2]
     except Exception:
         pass
 

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.2.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- Add `app_type` field to `clacks config info` output to show whether current context uses clacks, clacks-lite, or cookie authentication
- Bump version to 0.3.2