### PR TITLE
Fix rolodex issues from PR #53 review

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.4.0"
+version = "0.4.1"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/rolodex/cli.py
+++ b/src/slack_clacks/rolodex/cli.py
@@ -194,7 +194,7 @@ def generate_cli() -> argparse.ArgumentParser:
     add_parser.add_argument(
         "-o",
         "--outfile",
-        type=argparse.FileType("a"),
+        type=argparse.FileType("w"),
         default=sys.stdout,
         help="Output file for JSON results (default: stdout)",
     )
@@ -243,7 +243,7 @@ def generate_cli() -> argparse.ArgumentParser:
     list_parser.add_argument(
         "-o",
         "--outfile",
-        type=argparse.FileType("a"),
+        type=argparse.FileType("w"),
         default=sys.stdout,
         help="Output file for JSON results (default: stdout)",
     )
@@ -273,7 +273,7 @@ def generate_cli() -> argparse.ArgumentParser:
     remove_parser.add_argument(
         "-o",
         "--outfile",
-        type=argparse.FileType("a"),
+        type=argparse.FileType("w"),
         default=sys.stdout,
         help="Output file for JSON results (default: stdout)",
     )
@@ -291,7 +291,7 @@ def generate_cli() -> argparse.ArgumentParser:
     sync_parser.add_argument(
         "-o",
         "--outfile",
-        type=argparse.FileType("a"),
+        type=argparse.FileType("w"),
         default=sys.stdout,
         help="Output file for JSON results (default: stdout)",
     )
@@ -311,7 +311,7 @@ def generate_cli() -> argparse.ArgumentParser:
     platforminfo_parser.add_argument(
         "-o",
         "--outfile",
-        type=argparse.FileType("a"),
+        type=argparse.FileType("w"),
         default=sys.stdout,
         help="Output file for JSON results (default: stdout)",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Fixes several issues identified in #56 (post-merge review of PR #53).

### Changes

- **Atomic upsert in add_alias**: Uses `ON CONFLICT DO UPDATE` to eliminate race condition
- **Sync preserves manual aliases**: Uses `ON CONFLICT DO NOTHING` so manual aliases aren't overwritten
- **Pagination in resolve functions**: `resolve_user_id()` and `resolve_channel_id()` now paginate through all results
- **outfile mode**: Changed from append (`"a"`) to write (`"w"`) to produce valid JSON
- **Use constants**: `sync_from_slack` now uses `SLACK`, `USER`, `CHANNEL` constants

Fixes #56