### PR TITLE
feat: add 'Sent via clacks' footer to outbound messages

### DIFF
--- a/src/slack_clacks/messaging/cli.py
+++ b/src/slack_clacks/messaging/cli.py
@@ -47,7 +47,13 @@ def handle_send(args: argparse.Namespace) -> None:
         else:
             raise ValueError("Must specify either --channel or --user.")
 
-        response = send_message(client, channel_id, args.message, thread_ts=args.thread)
+        response = send_message(
+            client,
+            channel_id,
+            args.message,
+            thread_ts=args.thread,
+            incognito=args.incognito,
+        )
 
         with args.outfile as ofp:
             json.dump(response.data, ofp)
@@ -89,6 +95,11 @@ def generate_send_parser() -> argparse.ArgumentParser:
         "--thread",
         type=str,
         help="Thread timestamp for replying to thread",
+    )
+    parser.add_argument(
+        "--incognito",
+        action="store_true",
+        help="Send without the clacks footer",
     )
     parser.add_argument(
         "-o",

--- a/src/slack_clacks/messaging/operations.py
+++ b/src/slack_clacks/messaging/operations.py
@@ -165,12 +165,25 @@ def send_message(
     channel: str,
     text: str,
     thread_ts: str | None = None,
+    incognito: bool = False,
 ):
     """
     Send a message to a channel or DM.
     Returns the Slack API response.
     """
-    return client.chat_postMessage(channel=channel, text=text, thread_ts=thread_ts)
+    if incognito:
+        return client.chat_postMessage(channel=channel, text=text, thread_ts=thread_ts)
+
+    blocks: list[dict[str, object]] = [
+        {"type": "section", "text": {"type": "mrkdwn", "text": text}},
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": "Sent via clacks"}],
+        },
+    ]
+    return client.chat_postMessage(
+        channel=channel, text=text, blocks=blocks, thread_ts=thread_ts
+    )
 
 
 def read_messages(


### PR DESCRIPTION
## Summary

- Adds a Slack Block Kit context block to all outbound messages, rendering a small grey "Sent via clacks" attribution line below the message body
- Adds `--incognito` flag to `clacks send` to skip the footer

## Test plan

- [x] Tested `clacks send` with footer rendering in Slack DM
- [x] Tested `clacks send --incognito` sends without footer
- [x] Tested sending to a channel
- [x] Tested thread replies with and without footer