### PR TITLE
Harden skill install and ship full skill bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,17 @@ clacks rolodex platforminfo -p github
 
 clacks supports the [Agent Skills](https://agentskills.io) open standard for AI coding assistants.
 
+Codex quick install (global):
+```bash
+clacks skill --mode codex
+# or: uvx --from slack-clacks clacks skill --mode codex
+```
+
+Reinstall/update an existing skill install:
+```bash
+clacks skill --mode codex --force
+```
+
 Print SKILL.md to stdout:
 ```bash
 clacks skill
@@ -243,6 +254,8 @@ clacks skill --mode github
 ```
 
 All modes support `-global` and `-project` suffixes (e.g., `claude-project`, `codex-global`).
+Install writes a full skill bundle: `SKILL.md`, `agents/openai.yaml`, and `LICENSE.txt`.
+If the target skill directory already exists, pass `--force` to overwrite.
 
 ## Output
 

--- a/src/slack_clacks/skill/bundle/LICENSE.txt
+++ b/src/slack_clacks/skill/bundle/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Neeraj Kashyap
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/slack_clacks/skill/bundle/SKILL.md
+++ b/src/slack_clacks/skill/bundle/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: clacks
+description: >-
+  Send and read Slack messages using clacks CLI. Use when user asks to send
+  Slack messages, read channels, wait for responses, or interact with Slack.
+---
+
+# Slack Integration via Clacks
+
+Use the `clacks` CLI to interact with Slack workspaces.
+
+## Prerequisites
+
+Authenticate with your Slack workspace (requires uv):
+```bash
+uvx --from slack-clacks clacks auth login -c <context-name>
+```
+
+Using `uvx` ensures you always run the latest version. If clacks is installed globally
+via `uv tool install slack-clacks` or `pip install slack-clacks`, use `clacks` directly.
+
+## Sending Messages
+
+Send to channel:
+```bash
+uvx --from slack-clacks clacks send -c "#general" -m "Hello world"
+uvx --from slack-clacks clacks send -c "C123456" -m "Hello world"
+```
+
+Send direct message:
+```bash
+uvx --from slack-clacks clacks send -u "@username" -m "Hello"
+uvx --from slack-clacks clacks send -u "U123456" -m "Hello"
+```
+
+Reply to thread:
+```bash
+uvx --from slack-clacks clacks send -c "#general" -m "Reply text" -t "1234567890.123456"
+```
+
+## Reading Messages
+
+Read from channel:
+```bash
+uvx --from slack-clacks clacks read -c "#general"
+uvx --from slack-clacks clacks read -c "#general" -l 50
+```
+
+Read DMs:
+```bash
+uvx --from slack-clacks clacks read -u "@username"
+```
+
+Read thread:
+```bash
+uvx --from slack-clacks clacks read -c "#general" -t "1234567890.123456"
+```
+
+## Recent Activity
+
+View recent messages across all conversations:
+```bash
+uvx --from slack-clacks clacks recent
+uvx --from slack-clacks clacks recent -l 50
+```
+
+## Reactions
+
+Add emoji reaction:
+```bash
+uvx --from slack-clacks clacks react -c "#general" -m "123456.123" -e ":+1:"
+```
+
+Remove reaction:
+```bash
+uvx --from slack-clacks clacks react -c "#general" -m "123456.123" -e ":+1:" --remove
+```
+
+## Delete Messages
+
+Delete a message (your own messages only):
+```bash
+uvx --from slack-clacks clacks delete -c "#general" -m "1234567890.123456"
+```
+
+## Uploading Files and Snippets
+
+Upload a file to a channel:
+```bash
+uvx --from slack-clacks clacks upload -c "#general" -f /path/to/file.py
+```
+
+Pipe command output as a snippet:
+```bash
+cat script.py | uvx --from slack-clacks clacks upload -c "#ops" -t python
+```
+
+Private upload (returns permalink, not shared to any channel):
+```bash
+echo "print('hello')" | uvx --from slack-clacks clacks upload -t python
+```
+
+## Rolodex (Aliases)
+
+Sync users and channels from Slack:
+```bash
+uvx --from slack-clacks clacks rolodex sync
+```
+
+List aliases:
+```bash
+uvx --from slack-clacks clacks rolodex list
+uvx --from slack-clacks clacks rolodex list -T user
+uvx --from slack-clacks clacks rolodex list -T channel
+```
+
+## Listening for Messages
+
+Listen for new messages in a channel (outputs NDJSON, one message per line):
+```bash
+uvx --from slack-clacks clacks listen "#general"
+```
+
+Listen with history (fetch last N messages first):
+```bash
+uvx --from slack-clacks clacks listen "#general" --include-history 5
+```
+
+Listen to thread replies:
+```bash
+uvx --from slack-clacks clacks listen "#general" --thread "1234567890.123456"
+```
+
+Filter by sender (wait for response from specific user):
+```bash
+uvx --from slack-clacks clacks listen "#general" --from "@username"
+```
+
+Set timeout (exit after N seconds):
+```bash
+uvx --from slack-clacks clacks listen "#general" --timeout 300
+```
+
+Options:
+- `--interval SECONDS` - Poll interval (default: 2.0)
+- `--include-bots` - Include bot messages (excluded by default)
+- `-o FILE` - Write to file instead of stdout
+
+### When to Use Listen
+
+Use `clacks listen` when:
+- Waiting for a response from someone after sending a message
+- Monitoring a channel for new activity
+- Waiting for a specific user to reply in a thread
+
+Example workflow - send message and wait for reply:
+```bash
+# Send a message
+uvx --from slack-clacks clacks send -c "#general" -m "Question for @alice"
+
+# Wait for alice's response (timeout after 5 minutes)
+uvx --from slack-clacks clacks listen "#general" --from "@alice" --timeout 300
+```
+
+## Context Management
+
+List available contexts:
+```bash
+uvx --from slack-clacks clacks config contexts
+```
+
+Switch context:
+```bash
+uvx --from slack-clacks clacks config switch -C <context-name>
+```
+
+View current config:
+```bash
+uvx --from slack-clacks clacks config info
+```
+
+## Output
+
+All commands output JSON to stdout.
+The `listen` command outputs NDJSON (one JSON object per line).

--- a/src/slack_clacks/skill/bundle/agents/openai.yaml
+++ b/src/slack_clacks/skill/bundle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Clacks"
+  short_description: "Send and read Slack messages in Codex"
+  default_prompt: "Use $clacks to send, read, and monitor Slack messages for this task."

--- a/src/slack_clacks/skill/cli.py
+++ b/src/slack_clacks/skill/cli.py
@@ -3,69 +3,88 @@ CLI for skill command.
 """
 
 import argparse
+import shutil
 import sys
 from pathlib import Path
 
-from slack_clacks.skill.content import SKILL_MD
+from slack_clacks.skill.content import get_bundle_contents, get_skill_md
 
-# Mode -> path mapping
+# Mode -> directory mapping
 # Global paths use ~ expansion, project paths are relative to cwd
-MODE_PATHS: dict[str, str] = {
-    "claude": "~/.claude/skills/clacks/SKILL.md",
-    "claude-global": "~/.claude/skills/clacks/SKILL.md",
-    "claude-project": ".claude/skills/clacks/SKILL.md",
-    "codex": "~/.codex/skills/clacks/SKILL.md",
-    "codex-global": "~/.codex/skills/clacks/SKILL.md",
-    "codex-project": ".codex/skills/clacks/SKILL.md",
-    "universal": "~/.agent/skills/clacks/SKILL.md",
-    "universal-global": "~/.agent/skills/clacks/SKILL.md",
-    "universal-project": ".agent/skills/clacks/SKILL.md",
-    "github": ".github/skills/clacks/SKILL.md",
+MODE_DIRS: dict[str, str] = {
+    "claude": "~/.claude/skills/clacks",
+    "claude-global": "~/.claude/skills/clacks",
+    "claude-project": ".claude/skills/clacks",
+    "codex": "~/.codex/skills/clacks",
+    "codex-global": "~/.codex/skills/clacks",
+    "codex-project": ".codex/skills/clacks",
+    "universal": "~/.agent/skills/clacks",
+    "universal-global": "~/.agent/skills/clacks",
+    "universal-project": ".agent/skills/clacks",
+    "github": ".github/skills/clacks",
 }
+
+
+def _resolve_install_dir(args: argparse.Namespace) -> Path | None:
+    """Resolve the destination directory for bundle installation."""
+    if args.outdir is not None:
+        return Path(args.outdir).expanduser()
+    if args.mode is not None:
+        if args.mode not in MODE_DIRS:
+            valid_modes = ", ".join(sorted(MODE_DIRS.keys()))
+            print(f"Unknown mode: {args.mode}", file=sys.stderr)
+            print(f"Valid modes: {valid_modes}", file=sys.stderr)
+            sys.exit(1)
+        return Path(MODE_DIRS[args.mode]).expanduser()
+    return None
+
+
+def _install_bundle(path: Path, force: bool) -> None:
+    """Install the bundled skill files to a target directory."""
+    if path.exists():
+        if not force:
+            print(f"Skill directory already exists: {path}", file=sys.stderr)
+            print("Use --force to overwrite it", file=sys.stderr)
+            sys.exit(1)
+        if path.is_dir():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+
+    path.mkdir(parents=True, exist_ok=True)
+    for relative_path, content in get_bundle_contents().items():
+        destination = path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(content, encoding="utf-8")
 
 
 def handle_skill(args: argparse.Namespace) -> None:
     """Handle skill command."""
-    # Determine output path
-    if args.outdir is not None:
-        outdir = Path(args.outdir).expanduser()
-        path = outdir / "SKILL.md"
-    elif args.mode is not None:
-        if args.mode not in MODE_PATHS:
-            valid_modes = ", ".join(sorted(MODE_PATHS.keys()))
-            print(f"Unknown mode: {args.mode}", file=sys.stderr)
-            print(f"Valid modes: {valid_modes}", file=sys.stderr)
-            sys.exit(1)
-        path = Path(MODE_PATHS[args.mode]).expanduser()
-    else:
-        # Default: print to stdout
-        print(SKILL_MD)
+    install_dir = _resolve_install_dir(args)
+    if install_dir is None:
+        # Default: print SKILL.md to stdout
+        print(get_skill_md())
         return
 
-    # Check if parent directory exists
-    if not path.parent.exists():
-        if not args.force:
-            print(f"Directory does not exist: {path.parent}", file=sys.stderr)
-            print("Use --force to create it", file=sys.stderr)
-            sys.exit(1)
-        path.parent.mkdir(parents=True, exist_ok=True)
+    if not install_dir.parent.exists():
+        # Create top-level parent directory chain when needed.
+        install_dir.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write SKILL.md
-    path.write_text(SKILL_MD)
-    print(f"Installed skill to: {path}")
+    _install_bundle(install_dir, args.force)
+    print(f"Installed skill bundle to: {install_dir}")
 
 
 def generate_cli() -> argparse.ArgumentParser:
     """Generate skill CLI parser."""
     parser = argparse.ArgumentParser(
-        description="Output or install Agent Skills spec (agentskills.io) SKILL.md"
+        description="Output or install Agent Skills spec (agentskills.io) bundle."
     )
     output_group = parser.add_mutually_exclusive_group()
     output_group.add_argument(
         "-m",
         "--mode",
         type=str,
-        choices=list(MODE_PATHS.keys()),
+        choices=list(MODE_DIRS.keys()),
         default=None,
         help="Installation mode. Without this flag, prints SKILL.md to stdout.",
     )
@@ -74,13 +93,13 @@ def generate_cli() -> argparse.ArgumentParser:
         "--outdir",
         type=str,
         default=None,
-        help="Output directory for SKILL.md (writes SKILL.md to this path).",
+        help="Output directory for skill bundle (writes SKILL.md and support files).",
     )
     parser.add_argument(
         "-f",
         "--force",
         action="store_true",
-        help="Create parent directories if they don't exist.",
+        help="Overwrite existing skill directory.",
     )
     parser.set_defaults(func=handle_skill)
     return parser

--- a/src/slack_clacks/skill/content.py
+++ b/src/slack_clacks/skill/content.py
@@ -1,191 +1,26 @@
 """
-SKILL.md content for clacks.
+Skill bundle content loader for clacks.
 """
 
-SKILL_MD = """\
----
-name: clacks
-description: >-
-  Send and read Slack messages using clacks CLI. Use when user asks to send
-  Slack messages, read channels, wait for responses, or interact with Slack.
----
+from importlib.resources import files
 
-# Slack Integration via Clacks
+BUNDLE_ROOT = files("slack_clacks.skill").joinpath("bundle")
 
-Use the `clacks` CLI to interact with Slack workspaces.
+BUNDLE_PATHS: tuple[str, ...] = (
+    "SKILL.md",
+    "agents/openai.yaml",
+    "LICENSE.txt",
+)
 
-## Prerequisites
 
-Authenticate with your Slack workspace (requires uv):
-```bash
-uvx --from slack-clacks clacks auth login -c <context-name>
-```
+def get_bundle_contents() -> dict[str, str]:
+    """Return bundled skill files keyed by relative path."""
+    return {
+        relative_path: BUNDLE_ROOT.joinpath(relative_path).read_text(encoding="utf-8")
+        for relative_path in BUNDLE_PATHS
+    }
 
-Using `uvx` ensures you always run the latest version. If clacks is installed globally
-via `uv tool install slack-clacks` or `pip install slack-clacks`, use `clacks` directly.
 
-## Sending Messages
-
-Send to channel:
-```bash
-uvx --from slack-clacks clacks send -c "#general" -m "Hello world"
-uvx --from slack-clacks clacks send -c "C123456" -m "Hello world"
-```
-
-Send direct message:
-```bash
-uvx --from slack-clacks clacks send -u "@username" -m "Hello"
-uvx --from slack-clacks clacks send -u "U123456" -m "Hello"
-```
-
-Reply to thread:
-```bash
-uvx --from slack-clacks clacks send -c "#general" -m "Reply text" -t "1234567890.123456"
-```
-
-## Reading Messages
-
-Read from channel:
-```bash
-uvx --from slack-clacks clacks read -c "#general"
-uvx --from slack-clacks clacks read -c "#general" -l 50
-```
-
-Read DMs:
-```bash
-uvx --from slack-clacks clacks read -u "@username"
-```
-
-Read thread:
-```bash
-uvx --from slack-clacks clacks read -c "#general" -t "1234567890.123456"
-```
-
-## Recent Activity
-
-View recent messages across all conversations:
-```bash
-uvx --from slack-clacks clacks recent
-uvx --from slack-clacks clacks recent -l 50
-```
-
-## Reactions
-
-Add emoji reaction:
-```bash
-uvx --from slack-clacks clacks react -c "#general" -m "123456.123" -e ":+1:"
-```
-
-Remove reaction:
-```bash
-uvx --from slack-clacks clacks react -c "#general" -m "123456.123" -e ":+1:" --remove
-```
-
-## Delete Messages
-
-Delete a message (your own messages only):
-```bash
-uvx --from slack-clacks clacks delete -c "#general" -m "1234567890.123456"
-```
-
-## Uploading Files and Snippets
-
-Upload a file to a channel:
-```bash
-uvx --from slack-clacks clacks upload -c "#general" -f /path/to/file.py
-```
-
-Pipe command output as a snippet:
-```bash
-cat script.py | uvx --from slack-clacks clacks upload -c "#ops" -t python
-```
-
-Private upload (returns permalink, not shared to any channel):
-```bash
-echo "print('hello')" | uvx --from slack-clacks clacks upload -t python
-```
-
-## Rolodex (Aliases)
-
-Sync users and channels from Slack:
-```bash
-uvx --from slack-clacks clacks rolodex sync
-```
-
-List aliases:
-```bash
-uvx --from slack-clacks clacks rolodex list
-uvx --from slack-clacks clacks rolodex list -T user
-uvx --from slack-clacks clacks rolodex list -T channel
-```
-
-## Listening for Messages
-
-Listen for new messages in a channel (outputs NDJSON, one message per line):
-```bash
-uvx --from slack-clacks clacks listen "#general"
-```
-
-Listen with history (fetch last N messages first):
-```bash
-uvx --from slack-clacks clacks listen "#general" --include-history 5
-```
-
-Listen to thread replies:
-```bash
-uvx --from slack-clacks clacks listen "#general" --thread "1234567890.123456"
-```
-
-Filter by sender (wait for response from specific user):
-```bash
-uvx --from slack-clacks clacks listen "#general" --from "@username"
-```
-
-Set timeout (exit after N seconds):
-```bash
-uvx --from slack-clacks clacks listen "#general" --timeout 300
-```
-
-Options:
-- `--interval SECONDS` - Poll interval (default: 2.0)
-- `--include-bots` - Include bot messages (excluded by default)
-- `-o FILE` - Write to file instead of stdout
-
-### When to Use Listen
-
-Use `clacks listen` when:
-- Waiting for a response from someone after sending a message
-- Monitoring a channel for new activity
-- Waiting for a specific user to reply in a thread
-
-Example workflow - send message and wait for reply:
-```bash
-# Send a message
-uvx --from slack-clacks clacks send -c "#general" -m "Question for @alice"
-
-# Wait for alice's response (timeout after 5 minutes)
-uvx --from slack-clacks clacks listen "#general" --from "@alice" --timeout 300
-```
-
-## Context Management
-
-List available contexts:
-```bash
-uvx --from slack-clacks clacks config contexts
-```
-
-Switch context:
-```bash
-uvx --from slack-clacks clacks config switch -C <context-name>
-```
-
-View current config:
-```bash
-uvx --from slack-clacks clacks config info
-```
-
-## Output
-
-All commands output JSON to stdout.
-The `listen` command outputs NDJSON (one JSON object per line).
-"""
+def get_skill_md() -> str:
+    """Return SKILL.md from the bundled resources."""
+    return BUNDLE_ROOT.joinpath("SKILL.md").read_text(encoding="utf-8")

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -1,0 +1,130 @@
+import argparse
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from slack_clacks.skill import cli as skill_cli
+from slack_clacks.skill.content import get_bundle_contents, get_skill_md
+
+
+class TestSkillCommand(unittest.TestCase):
+    def _run_handle_skill(self, args: argparse.Namespace) -> tuple[int, str, str]:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            try:
+                skill_cli.handle_skill(args)
+                return 0, stdout.getvalue(), stderr.getvalue()
+            except SystemExit as exc:
+                return int(exc.code), stdout.getvalue(), stderr.getvalue()
+
+    def test_prints_skill_md_when_no_output_args(self):
+        args = argparse.Namespace(mode=None, outdir=None, force=False)
+
+        code, stdout, stderr = self._run_handle_skill(args)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(stdout, f"{get_skill_md()}\n")
+        self.assertEqual(stderr, "")
+
+    def test_mode_install_creates_missing_directories_and_bundle_files(self):
+        bundle = get_bundle_contents()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_dir = Path(tmpdir) / "nested" / "codex" / "skills" / "clacks"
+            with patch.dict(skill_cli.MODE_DIRS, {"codex": str(install_dir)}):
+                args = argparse.Namespace(mode="codex", outdir=None, force=False)
+                code, stdout, stderr = self._run_handle_skill(args)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(stderr, "")
+            self.assertIn("Installed skill bundle to:", stdout)
+            self.assertTrue(install_dir.is_dir())
+            for relative_path, expected_content in bundle.items():
+                file_path = install_dir / relative_path
+                self.assertTrue(file_path.exists())
+                self.assertEqual(
+                    file_path.read_text(encoding="utf-8"), expected_content
+                )
+
+    def test_mode_install_fails_if_target_exists_without_force(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_dir = Path(tmpdir) / "skills" / "clacks"
+            install_dir.mkdir(parents=True)
+            with patch.dict(skill_cli.MODE_DIRS, {"codex": str(install_dir)}):
+                args = argparse.Namespace(mode="codex", outdir=None, force=False)
+                code, stdout, stderr = self._run_handle_skill(args)
+
+        self.assertEqual(code, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("Skill directory already exists", stderr)
+        self.assertIn("Use --force to overwrite it", stderr)
+
+    def test_mode_install_overwrites_existing_target_with_force(self):
+        bundle = get_bundle_contents()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_dir = Path(tmpdir) / "skills" / "clacks"
+            install_dir.mkdir(parents=True)
+            (install_dir / "SKILL.md").write_text("stale", encoding="utf-8")
+            (install_dir / "stale.txt").write_text("remove me", encoding="utf-8")
+
+            with patch.dict(skill_cli.MODE_DIRS, {"codex": str(install_dir)}):
+                args = argparse.Namespace(mode="codex", outdir=None, force=True)
+                code, stdout, stderr = self._run_handle_skill(args)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(stderr, "")
+            self.assertIn("Installed skill bundle to:", stdout)
+            self.assertFalse((install_dir / "stale.txt").exists())
+            for relative_path, expected_content in bundle.items():
+                file_path = install_dir / relative_path
+                self.assertTrue(file_path.exists())
+                self.assertEqual(
+                    file_path.read_text(encoding="utf-8"), expected_content
+                )
+
+    def test_outdir_install_and_overwrite_semantics_match_mode(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_dir = Path(tmpdir) / "outdir-skill"
+            args = argparse.Namespace(mode=None, outdir=str(install_dir), force=False)
+            first_code, _, first_stderr = self._run_handle_skill(args)
+            second_code, _, second_stderr = self._run_handle_skill(args)
+
+            force_args = argparse.Namespace(
+                mode=None, outdir=str(install_dir), force=True
+            )
+            third_code, _, third_stderr = self._run_handle_skill(force_args)
+
+        self.assertEqual(first_code, 0)
+        self.assertEqual(first_stderr, "")
+        self.assertEqual(second_code, 1)
+        self.assertIn("Skill directory already exists", second_stderr)
+        self.assertIn("Use --force to overwrite it", second_stderr)
+        self.assertEqual(third_code, 0)
+        self.assertEqual(third_stderr, "")
+
+    def test_installed_openai_yaml_has_expected_interface_fields(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_dir = Path(tmpdir) / "skills" / "clacks"
+            with patch.dict(skill_cli.MODE_DIRS, {"codex": str(install_dir)}):
+                args = argparse.Namespace(mode="codex", outdir=None, force=False)
+                code, _, stderr = self._run_handle_skill(args)
+
+            self.assertEqual(code, 0)
+            self.assertEqual(stderr, "")
+
+            openai_yaml = (install_dir / "agents" / "openai.yaml").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn('display_name: "Clacks"', openai_yaml)
+            self.assertIn(
+                'short_description: "Send and read Slack messages in Codex"',
+                openai_yaml,
+            )
+            self.assertIn("$clacks", openai_yaml)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor `clacks skill` install targets from single-file writes to directory-based bundle installs
- auto-create missing parent directories for all install modes (`claude*`, `codex*`, `universal*`, `github`)
- change `--force` semantics to overwrite an existing skill directory
- keep `clacks skill` (no flags) behavior unchanged: print `SKILL.md`
- add bundled artifacts: `SKILL.md`, `agents/openai.yaml`, and `LICENSE.txt`
- update README with Codex quick install and reinstall instructions

## Tests
- added `tests/test_skill.py` covering:
  - stdout mode behavior
  - install to missing path creates bundle files
  - existing target fails without `--force`
  - overwrite behavior with `--force`
  - `--outdir` parity with mode installs
  - expected `agents/openai.yaml` fields including `$clacks`

## Validation
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run mypy src/`
- `uv run python -m unittest discover -s tests`
