### PR TITLE
Remove rolodex list default limit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.10.0"
+version = "0.10.1"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/rolodex/cli.py
+++ b/src/slack_clacks/rolodex/cli.py
@@ -231,8 +231,8 @@ def generate_cli() -> argparse.ArgumentParser:
         "-l",
         "--limit",
         type=int,
-        default=100,
-        help="Maximum results (default: 100)",
+        default=None,
+        help="Maximum results",
     )
     list_parser.add_argument(
         "--offset",

--- a/src/slack_clacks/rolodex/operations.py
+++ b/src/slack_clacks/rolodex/operations.py
@@ -91,7 +91,7 @@ def list_aliases(
     platform: str | None = None,
     target_type: str | None = None,
     target_id: str | None = None,
-    limit: int = 100,
+    limit: int | None = None,
     offset: int = 0,
 ) -> list[Alias]:
     """List aliases with optional filtering."""
@@ -102,7 +102,12 @@ def list_aliases(
         query = query.filter(Alias.target_type == target_type)
     if target_id is not None:
         query = query.filter(Alias.target_id == target_id)
-    return query.order_by(Alias.alias).limit(limit).offset(offset).all()
+    query = query.order_by(Alias.alias)
+    if limit is not None:
+        query = query.limit(limit)
+    if offset:
+        query = query.offset(offset)
+    return query.all()
 
 
 def remove_alias(

--- a/tests/test_rolodex.py
+++ b/tests/test_rolodex.py
@@ -90,5 +90,62 @@ class TestRolodexCascadeDelete(unittest.TestCase):
             self.assertEqual(aliases[0].context, "ctx-b")
 
 
+class TestRolodexListLimits(unittest.TestCase):
+    def setUp(self):
+        self.engine = get_engine(config_dir=":memory:")
+        with self.engine.connect() as connection:
+            run_migrations(connection)
+
+        with Session(self.engine) as session:
+            add_context(
+                session,
+                name="test-ctx",
+                access_token="fake-token",
+                user_id="U000000001",
+                workspace_id="T000000001",
+                app_type="clacks",
+            )
+            session.commit()
+
+    def tearDown(self):
+        self.engine.dispose()
+
+    def test_list_aliases_returns_all_results_by_default(self):
+        with Session(self.engine) as session:
+            for index in range(150):
+                add_alias(
+                    session,
+                    f"user-{index:03d}",
+                    "test-ctx",
+                    "user",
+                    "slack",
+                    f"U{index:09d}",
+                )
+            session.commit()
+
+        with Session(self.engine) as session:
+            aliases = list_aliases(session, "test-ctx")
+
+        self.assertEqual(len(aliases), 150)
+
+    def test_list_aliases_still_honors_explicit_limit(self):
+        with Session(self.engine) as session:
+            for index in range(5):
+                add_alias(
+                    session,
+                    f"user-{index:03d}",
+                    "test-ctx",
+                    "user",
+                    "slack",
+                    f"U{index:09d}",
+                )
+            session.commit()
+
+        with Session(self.engine) as session:
+            aliases = list_aliases(session, "test-ctx", limit=2)
+
+        self.assertEqual(len(aliases), 2)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- remove the implicit 100-result cap from `clacks rolodex list`
- keep explicit `--limit` support for callers that want pagination
- add regression coverage for unbounded listing and explicit limit behavior

## Why
`rolodex list` silently returned only the first 100 aliases by default. That caused channels beyond index 100 to appear missing unless the caller knew to pass `--limit`, which is what surfaced in the referenced Slack thread.

## Validation
- `uv run python -m unittest tests.test_rolodex`
- `uv run python -m unittest tests.test_main`
- `uv run python -m unittest discover -s tests -p 'test_*.py'`
