### PR TITLE
Fix bundled skill install details

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.10.1"
+version = "0.10.2"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/skill/cli.py
+++ b/src/slack_clacks/skill/cli.py
@@ -18,9 +18,9 @@ MODE_DIRS: dict[str, str] = {
     "codex": "~/.codex/skills/clacks",
     "codex-global": "~/.codex/skills/clacks",
     "codex-project": ".codex/skills/clacks",
-    "universal": "~/.agent/skills/clacks",
-    "universal-global": "~/.agent/skills/clacks",
-    "universal-project": ".agent/skills/clacks",
+    "universal": "~/.agents/skills/clacks",
+    "universal-global": "~/.agents/skills/clacks",
+    "universal-project": ".agents/skills/clacks",
     "github": ".github/skills/clacks",
 }
 

--- a/src/slack_clacks/skill/content.py
+++ b/src/slack_clacks/skill/content.py
@@ -218,17 +218,17 @@ uvx --from slack-clacks clacks delete -c "#general" -m "1234567890.123456"
 
 Upload a file to a channel:
 ```bash
-uvx --from slack-clacks clacks upload -c "#general" -f /path/to/file.py
+uvx --from slack-clacks clacks files upload -c "#general" -f /path/to/file.py
 ```
 
 Pipe command output as a snippet:
 ```bash
-cat script.py | uvx --from slack-clacks clacks upload -c "#ops" -t python
+cat script.py | uvx --from slack-clacks clacks files upload -c "#ops" -t python
 ```
 
 Private upload (returns permalink, not shared to any channel):
 ```bash
-echo "print('hello')" | uvx --from slack-clacks clacks upload -t python
+echo "print('hello')" | uvx --from slack-clacks clacks files upload -t python
 ```
 
 ## Listening for Messages

--- a/src/slack_clacks/skill/content.py
+++ b/src/slack_clacks/skill/content.py
@@ -25,15 +25,9 @@ The rolodex maps `@display-names` to Slack user/channel IDs.
 **Always use the rolodex to resolve @-mentions** —
 never guess or hardcode Slack IDs.
 
-At the start of any conversation that uses clacks, check when
-the rolodex was last synced by reading
-`~/.claude/skills/clacks/.rolodex-last-sync`. If the file
-doesn't exist or the timestamp is older than 7 days,
-**ask the user** if they'd like to sync the rolodex before
-proceeding. Do not sync automatically — always ask first.
-
-After syncing, write the current ISO 8601 timestamp to
-`~/.claude/skills/clacks/.rolodex-last-sync`.
+At the start of any conversation that uses clacks, ask the user
+before running `clacks rolodex sync` if aliases may be stale.
+Do not sync automatically — always ask first.
 
 ```bash
 # Sync the rolodex

--- a/src/slack_clacks/skill/status.py
+++ b/src/slack_clacks/skill/status.py
@@ -33,11 +33,11 @@ def get_skill_install_candidates(
     return (
         ("codex-project", current_dir / ".codex" / "skills" / "clacks"),
         ("claude-project", current_dir / ".claude" / "skills" / "clacks"),
-        ("universal-project", current_dir / ".agent" / "skills" / "clacks"),
+        ("universal-project", current_dir / ".agents" / "skills" / "clacks"),
         ("github", current_dir / ".github" / "skills" / "clacks"),
         ("codex", home_dir / ".codex" / "skills" / "clacks"),
         ("claude", home_dir / ".claude" / "skills" / "clacks"),
-        ("universal", home_dir / ".agent" / "skills" / "clacks"),
+        ("universal", home_dir / ".agents" / "skills" / "clacks"),
     )
 
 

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -121,6 +121,12 @@ class TestSkillCommand(unittest.TestCase):
         self.assertEqual(third_code, 0)
         self.assertEqual(third_stderr, "")
 
+    def test_universal_mode_uses_agents_directory(self):
+        self.assertEqual(skill_cli.MODE_DIRS["universal"], "~/.agents/skills/clacks")
+        self.assertEqual(
+            skill_cli.MODE_DIRS["universal-project"], ".agents/skills/clacks"
+        )
+
     def test_installed_openai_yaml_has_expected_interface_fields(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             install_dir = Path(tmpdir) / "skills" / "clacks"
@@ -168,6 +174,23 @@ class TestSkillInstallStatus(unittest.TestCase):
             status = check_skill_install_status(cwd=cwd, home=home)
 
         self.assertIsNone(status)
+
+    def test_universal_install_status_uses_agents_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            cwd = root / "workspace"
+            home = root / "home"
+            cwd.mkdir()
+            home.mkdir()
+            install_dir = home / ".agents" / "skills" / "clacks"
+            self._write_bundle(install_dir)
+
+            status = check_skill_install_status(cwd=cwd, home=home)
+
+        self.assertIsNotNone(status)
+        assert status is not None
+        self.assertEqual(status.mode, "universal")
+        self.assertEqual(status.path, install_dir)
 
     def test_matching_installed_skill_is_current(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.10.2"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.10.0"
+version = "0.10.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## 🔍 Problem

- The universal skill install mode writes to `.agent/skills`, but the Agent Skills convention is `.agents/skills`.
- The bundled clacks skill references `clacks upload`, while the current CLI exposes uploads under `clacks files upload`.
- The skill tells agents to manage rolodex sync state in a Claude-specific skill directory, but `rolodex sync` does not persist such a timestamp.

## 🛠️ Solution

- Change universal install and stale-install detection paths to `.agents/skills`.
- Correct the three upload examples in the bundled skill.
- Remove the hard-coded `.claude/.../.rolodex-last-sync` instructions and keep ask-before-sync guidance.
- Add focused coverage for the universal path mapping and status detection.

## 💬 Review

- Minimal skill-install and bundled-skill corrections.