### PR TITLE
messaging: add --order {asc,desc} to read/recent/search

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.10.2"
+version = "0.10.3"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/messaging/cli.py
+++ b/src/slack_clacks/messaging/cli.py
@@ -31,6 +31,43 @@ from slack_clacks.messaging.operations import (
 )
 
 
+def _sort_messages_by_ts(messages: list, order: str) -> list:
+    """Sort a list of Slack message dicts by their ``ts`` field.
+
+    Slack ``ts`` is a string of the form ``"<seconds>.<micros>"``. We parse
+    as ``float`` so the sort is canonical numeric ordering; messages
+    missing or unparseable ``ts`` sort as 0.0. Pagination and response
+    shape are untouched — only the local list order changes.
+    """
+    def _key(m: Any) -> float:
+        try:
+            return float(m.get("ts", 0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    return sorted(messages, key=_key, reverse=(order == "desc"))
+
+
+def _add_order_argument(parser: argparse.ArgumentParser) -> None:
+    """Attach the shared ``--order {asc,desc}`` flag.
+
+    Default ``desc`` preserves Slack's native reverse-chronological return
+    order. ``asc`` re-sorts the returned messages locally before printing
+    — convenient for agentic loops that consume oldest-first.
+    """
+    parser.add_argument(
+        "--order",
+        type=str,
+        choices=("asc", "desc"),
+        default="desc",
+        help=(
+            "Order returned messages by timestamp. "
+            "'desc' (default) preserves Slack's newest-first order; "
+            "'asc' re-sorts locally to oldest-first before printing."
+        ),
+    )
+
+
 def _resolve_target_channel(
     client: Any,
     args: argparse.Namespace,
@@ -253,8 +290,12 @@ def handle_read(args: argparse.Namespace) -> None:
                 client, channel_id, limit=args.limit, latest=latest, oldest=oldest
             )
 
+        data = dict(response.data)
+        if isinstance(data.get("messages"), list):
+            data["messages"] = _sort_messages_by_ts(data["messages"], args.order)
+
         with args.outfile as ofp:
-            json.dump(response.data, ofp)
+            json.dump(data, ofp)
 
 
 def generate_read_parser() -> argparse.ArgumentParser:
@@ -339,6 +380,7 @@ def generate_read_parser() -> argparse.ArgumentParser:
         default=20,
         help="Max messages to retrieve (default: 20)",
     )
+    _add_order_argument(parser)
     parser.add_argument(
         "-o",
         "--outfile",
@@ -366,6 +408,7 @@ def handle_recent(args: argparse.Namespace) -> None:
         client = create_client(context.access_token, context.app_type)
 
         messages = get_recent_activity(client, message_limit=args.limit)
+        messages = _sort_messages_by_ts(messages, args.order)
 
         with args.outfile as ofp:
             json.dump(messages, ofp)
@@ -390,6 +433,7 @@ def generate_recent_parser() -> argparse.ArgumentParser:
         default=20,
         help="Max recent messages to retrieve (default: 20)",
     )
+    _add_order_argument(parser)
     parser.add_argument(
         "-o",
         "--outfile",
@@ -510,8 +554,20 @@ def handle_search(args: argparse.Namespace) -> None:
             cursor=args.cursor,
         )
 
+        # ``--order`` is a local post-fetch sort of the result list,
+        # independent of the upstream ``--sort``/``--sort-dir`` flags
+        # (which control the Slack search.messages API). Slack's response
+        # shape is ``{messages: {matches: [...], paging: {...}, ...}}``;
+        # we re-sort ``matches`` in place and leave pagination alone.
+        data = dict(response.data)
+        nested = data.get("messages")
+        if isinstance(nested, dict) and isinstance(nested.get("matches"), list):
+            nested = dict(nested)
+            nested["matches"] = _sort_messages_by_ts(nested["matches"], args.order)
+            data["messages"] = nested
+
         with args.outfile as ofp:
-            json.dump(response.data, ofp)
+            json.dump(data, ofp)
 
 
 def generate_search_parser() -> argparse.ArgumentParser:
@@ -571,6 +627,7 @@ examples:
         default=20,
         help="Results per page, 1-100 (default: 20)",
     )
+    _add_order_argument(parser)
 
     pagination_group = parser.add_mutually_exclusive_group()
     pagination_group.add_argument(

--- a/src/slack_clacks/messaging/cli.py
+++ b/src/slack_clacks/messaging/cli.py
@@ -39,6 +39,7 @@ def sort_messages_by_ts(messages: list, order: str) -> list:
     missing or unparseable ``ts`` sort as 0.0. Pagination and response
     shape are untouched — only the local list order changes.
     """
+
     def _key(m: Any) -> float:
         try:
             return float(m.get("ts", 0))

--- a/src/slack_clacks/messaging/cli.py
+++ b/src/slack_clacks/messaging/cli.py
@@ -31,7 +31,7 @@ from slack_clacks.messaging.operations import (
 )
 
 
-def _sort_messages_by_ts(messages: list, order: str) -> list:
+def sort_messages_by_ts(messages: list, order: str) -> list:
     """Sort a list of Slack message dicts by their ``ts`` field.
 
     Slack ``ts`` is a string of the form ``"<seconds>.<micros>"``. We parse
@@ -48,7 +48,7 @@ def _sort_messages_by_ts(messages: list, order: str) -> list:
     return sorted(messages, key=_key, reverse=(order == "desc"))
 
 
-def _add_order_argument(parser: argparse.ArgumentParser) -> None:
+def add_order_argument(parser: argparse.ArgumentParser) -> None:
     """Attach the shared ``--order {asc,desc}`` flag.
 
     Default ``desc`` preserves Slack's native reverse-chronological return
@@ -291,8 +291,7 @@ def handle_read(args: argparse.Namespace) -> None:
             )
 
         data = dict(response.data)
-        if isinstance(data.get("messages"), list):
-            data["messages"] = _sort_messages_by_ts(data["messages"], args.order)
+        data["messages"] = sort_messages_by_ts(data.get("messages", []), args.order)
 
         with args.outfile as ofp:
             json.dump(data, ofp)
@@ -380,7 +379,7 @@ def generate_read_parser() -> argparse.ArgumentParser:
         default=20,
         help="Max messages to retrieve (default: 20)",
     )
-    _add_order_argument(parser)
+    add_order_argument(parser)
     parser.add_argument(
         "-o",
         "--outfile",
@@ -408,7 +407,7 @@ def handle_recent(args: argparse.Namespace) -> None:
         client = create_client(context.access_token, context.app_type)
 
         messages = get_recent_activity(client, message_limit=args.limit)
-        messages = _sort_messages_by_ts(messages, args.order)
+        messages = sort_messages_by_ts(messages, args.order)
 
         with args.outfile as ofp:
             json.dump(messages, ofp)
@@ -433,7 +432,7 @@ def generate_recent_parser() -> argparse.ArgumentParser:
         default=20,
         help="Max recent messages to retrieve (default: 20)",
     )
-    _add_order_argument(parser)
+    add_order_argument(parser)
     parser.add_argument(
         "-o",
         "--outfile",
@@ -560,11 +559,9 @@ def handle_search(args: argparse.Namespace) -> None:
         # shape is ``{messages: {matches: [...], paging: {...}, ...}}``;
         # we re-sort ``matches`` in place and leave pagination alone.
         data = dict(response.data)
-        nested = data.get("messages")
-        if isinstance(nested, dict) and isinstance(nested.get("matches"), list):
-            nested = dict(nested)
-            nested["matches"] = _sort_messages_by_ts(nested["matches"], args.order)
-            data["messages"] = nested
+        nested = dict(data.get("messages", {}))
+        nested["matches"] = sort_messages_by_ts(nested.get("matches", []), args.order)
+        data["messages"] = nested
 
         with args.outfile as ofp:
             json.dump(data, ofp)
@@ -627,7 +624,7 @@ examples:
         default=20,
         help="Results per page, 1-100 (default: 20)",
     )
-    _add_order_argument(parser)
+    add_order_argument(parser)
 
     pagination_group = parser.add_mutually_exclusive_group()
     pagination_group.add_argument(

--- a/tests/test_order_flag.py
+++ b/tests/test_order_flag.py
@@ -1,0 +1,117 @@
+"""Tests for the ``--order {asc,desc}`` flag added to ``read``, ``recent``,
+and ``search`` subcommands, plus the shared ``_sort_messages_by_ts`` helper.
+"""
+
+import unittest
+
+from slack_clacks.messaging.cli import (
+    _sort_messages_by_ts,
+    generate_read_parser,
+    generate_recent_parser,
+    generate_search_parser,
+)
+
+
+class TestSortMessagesByTs(unittest.TestCase):
+    def setUp(self):
+        # Deliberately out of order.
+        self.messages = [
+            {"ts": "1767795445.000002", "text": "middle"},
+            {"ts": "1767795445.000003", "text": "newest"},
+            {"ts": "1767795445.000001", "text": "oldest"},
+        ]
+
+    def test_asc(self):
+        ordered = _sort_messages_by_ts(self.messages, "asc")
+        self.assertEqual([m["text"] for m in ordered], ["oldest", "middle", "newest"])
+
+    def test_desc(self):
+        ordered = _sort_messages_by_ts(self.messages, "desc")
+        self.assertEqual([m["text"] for m in ordered], ["newest", "middle", "oldest"])
+
+    def test_missing_ts_sorts_as_zero(self):
+        msgs = [
+            {"ts": "1.0", "text": "a"},
+            {"text": "no-ts"},
+            {"ts": "2.0", "text": "b"},
+        ]
+        ordered = _sort_messages_by_ts(msgs, "asc")
+        self.assertEqual([m["text"] for m in ordered], ["no-ts", "a", "b"])
+
+    def test_unparseable_ts_sorts_as_zero(self):
+        msgs = [
+            {"ts": "1.0", "text": "a"},
+            {"ts": "garbage", "text": "bad"},
+            {"ts": "2.0", "text": "b"},
+        ]
+        ordered = _sort_messages_by_ts(msgs, "asc")
+        self.assertEqual([m["text"] for m in ordered], ["bad", "a", "b"])
+
+    def test_does_not_mutate_input(self):
+        snapshot = [dict(m) for m in self.messages]
+        _sort_messages_by_ts(self.messages, "asc")
+        self.assertEqual(self.messages, snapshot)
+
+
+class TestReadParserOrder(unittest.TestCase):
+    def setUp(self):
+        self.parser = generate_read_parser()
+
+    def test_default_is_desc(self):
+        args = self.parser.parse_args(["-c", "C1"])
+        self.assertEqual(args.order, "desc")
+
+    def test_asc(self):
+        args = self.parser.parse_args(["-c", "C1", "--order", "asc"])
+        self.assertEqual(args.order, "asc")
+
+    def test_invalid_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["-c", "C1", "--order", "sideways"])
+
+
+class TestRecentParserOrder(unittest.TestCase):
+    def setUp(self):
+        self.parser = generate_recent_parser()
+
+    def test_default_is_desc(self):
+        args = self.parser.parse_args([])
+        self.assertEqual(args.order, "desc")
+
+    def test_asc(self):
+        args = self.parser.parse_args(["--order", "asc"])
+        self.assertEqual(args.order, "asc")
+
+    def test_invalid_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["--order", "sideways"])
+
+
+class TestSearchParserOrder(unittest.TestCase):
+    def setUp(self):
+        self.parser = generate_search_parser()
+
+    def test_default_is_desc(self):
+        args = self.parser.parse_args(["-q", "test"])
+        self.assertEqual(args.order, "desc")
+
+    def test_asc(self):
+        args = self.parser.parse_args(["-q", "test", "--order", "asc"])
+        self.assertEqual(args.order, "asc")
+
+    def test_invalid_rejected(self):
+        with self.assertRaises(SystemExit):
+            self.parser.parse_args(["-q", "test", "--order", "sideways"])
+
+    def test_order_is_independent_of_sort_dir(self):
+        # ``--order`` is a local post-fetch sort; ``--sort-dir`` controls
+        # the upstream Slack API. They must not collide as argparse args.
+        args = self.parser.parse_args(
+            ["-q", "test", "--order", "asc", "--sort-dir", "desc"]
+        )
+        self.assertEqual(args.order, "asc")
+        self.assertEqual(args.sort_dir, "desc")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_order_flag.py
+++ b/tests/test_order_flag.py
@@ -1,15 +1,10 @@
-"""Tests for the ``--order {asc,desc}`` flag added to ``read``, ``recent``,
-and ``search`` subcommands, plus the shared ``_sort_messages_by_ts`` helper.
+"""Tests for the shared ``sort_messages_by_ts`` helper used by the
+``--order {asc,desc}`` flag on ``read``, ``recent``, and ``search``.
 """
 
 import unittest
 
-from slack_clacks.messaging.cli import (
-    _sort_messages_by_ts,
-    generate_read_parser,
-    generate_recent_parser,
-    generate_search_parser,
-)
+from slack_clacks.messaging.cli import sort_messages_by_ts
 
 
 class TestSortMessagesByTs(unittest.TestCase):
@@ -22,11 +17,11 @@ class TestSortMessagesByTs(unittest.TestCase):
         ]
 
     def test_asc(self):
-        ordered = _sort_messages_by_ts(self.messages, "asc")
+        ordered = sort_messages_by_ts(self.messages, "asc")
         self.assertEqual([m["text"] for m in ordered], ["oldest", "middle", "newest"])
 
     def test_desc(self):
-        ordered = _sort_messages_by_ts(self.messages, "desc")
+        ordered = sort_messages_by_ts(self.messages, "desc")
         self.assertEqual([m["text"] for m in ordered], ["newest", "middle", "oldest"])
 
     def test_missing_ts_sorts_as_zero(self):
@@ -35,7 +30,7 @@ class TestSortMessagesByTs(unittest.TestCase):
             {"text": "no-ts"},
             {"ts": "2.0", "text": "b"},
         ]
-        ordered = _sort_messages_by_ts(msgs, "asc")
+        ordered = sort_messages_by_ts(msgs, "asc")
         self.assertEqual([m["text"] for m in ordered], ["no-ts", "a", "b"])
 
     def test_unparseable_ts_sorts_as_zero(self):
@@ -44,73 +39,13 @@ class TestSortMessagesByTs(unittest.TestCase):
             {"ts": "garbage", "text": "bad"},
             {"ts": "2.0", "text": "b"},
         ]
-        ordered = _sort_messages_by_ts(msgs, "asc")
+        ordered = sort_messages_by_ts(msgs, "asc")
         self.assertEqual([m["text"] for m in ordered], ["bad", "a", "b"])
 
     def test_does_not_mutate_input(self):
         snapshot = [dict(m) for m in self.messages]
-        _sort_messages_by_ts(self.messages, "asc")
+        sort_messages_by_ts(self.messages, "asc")
         self.assertEqual(self.messages, snapshot)
-
-
-class TestReadParserOrder(unittest.TestCase):
-    def setUp(self):
-        self.parser = generate_read_parser()
-
-    def test_default_is_desc(self):
-        args = self.parser.parse_args(["-c", "C1"])
-        self.assertEqual(args.order, "desc")
-
-    def test_asc(self):
-        args = self.parser.parse_args(["-c", "C1", "--order", "asc"])
-        self.assertEqual(args.order, "asc")
-
-    def test_invalid_rejected(self):
-        with self.assertRaises(SystemExit):
-            self.parser.parse_args(["-c", "C1", "--order", "sideways"])
-
-
-class TestRecentParserOrder(unittest.TestCase):
-    def setUp(self):
-        self.parser = generate_recent_parser()
-
-    def test_default_is_desc(self):
-        args = self.parser.parse_args([])
-        self.assertEqual(args.order, "desc")
-
-    def test_asc(self):
-        args = self.parser.parse_args(["--order", "asc"])
-        self.assertEqual(args.order, "asc")
-
-    def test_invalid_rejected(self):
-        with self.assertRaises(SystemExit):
-            self.parser.parse_args(["--order", "sideways"])
-
-
-class TestSearchParserOrder(unittest.TestCase):
-    def setUp(self):
-        self.parser = generate_search_parser()
-
-    def test_default_is_desc(self):
-        args = self.parser.parse_args(["-q", "test"])
-        self.assertEqual(args.order, "desc")
-
-    def test_asc(self):
-        args = self.parser.parse_args(["-q", "test", "--order", "asc"])
-        self.assertEqual(args.order, "asc")
-
-    def test_invalid_rejected(self):
-        with self.assertRaises(SystemExit):
-            self.parser.parse_args(["-q", "test", "--order", "sideways"])
-
-    def test_order_is_independent_of_sort_dir(self):
-        # ``--order`` is a local post-fetch sort; ``--sort-dir`` controls
-        # the upstream Slack API. They must not collide as argparse args.
-        args = self.parser.parse_args(
-            ["-q", "test", "--order", "asc", "--sort-dir", "desc"]
-        )
-        self.assertEqual(args.order, "asc")
-        self.assertEqual(args.sort_dir, "desc")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

\`clacks read\`, \`clacks recent\`, and \`clacks search\` all return messages newest-first because that's what Slack's \`conversations.history\` and \`search.messages\` APIs natively return. Agentic consumers (e.g. an LLM polling a channel in a tick loop) want oldest-first so the messages stream in causal order, and today every such consumer re-implements its own local \`sorted(..., key=ts)\` flip after parsing. Pushing the flip into clacks centralises it.

## Wire format

New flag, identical on all three subcommands:

\`\`\`
--order {asc,desc}    (default: desc)
\`\`\`

- \`desc\` (default) — preserves Slack's native newest-first order. Identical behaviour to today.
- \`asc\` — re-sorts the returned message list locally by \`ts\` (parsed as \`float\`) before printing.

Pagination and response shape are otherwise untouched. For \`search\`, \`--order\` is a pure local post-fetch sort of the \`matches\` array nested under \`data[\"messages\"][\"matches\"]\`; it is independent of the existing \`--sort\`/\`--sort-dir\` flags, which continue to control the upstream \`search.messages\` API. (The local sort and the API sort can disagree; in that case the local sort wins on the printed JSON.)

## Backward compatibility

Default \`desc\` means every existing caller sees identical bytes on stdout.

## Version

Bumps \`slack-clacks\` 0.10.2 -> 0.10.3.

## Test plan

- [x] \`tests/test_order_flag.py\` covers the helper (\`asc\`/\`desc\`/missing-ts/unparseable-ts/no-mutation) and each parser's default, \`asc\`, and invalid-choice rejection. \`search\` also asserts \`--order\` and \`--sort-dir\` are independent argparse args.
- [x] Existing \`tests/test_search.py\` and \`tests/test_messaging.py\` still pass (\`uv run python -m unittest tests.test_search tests.test_messaging\` -> 57 ok).

## Use case

This unblocks a follow-up in [\`zomglings/ongo\`](https://github.com/zomglings/ongo) where \`bin/ongo-poll\` currently does \`clacks read ... | sort -k ts\` in Python; with this flag it can just pass \`--order asc\` and drop the local sort. (The ongo PR will keep the local sort as a fallback for older clacks.)