### PR TITLE
Add --context override flag to context-executing commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.10.3"
+version = "0.11.0"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/auth/cli.py
+++ b/src/slack_clacks/auth/cli.py
@@ -6,6 +6,7 @@ from slack_clacks.auth.cert import generate_self_signed_cert, get_cert_info
 from slack_clacks.auth.constants import MODE_CLACKS, MODE_CLACKS_LITE, MODE_COOKIE
 from slack_clacks.auth.cookie import authenticate_with_cookie
 from slack_clacks.auth.oauth import start_oauth_flow
+from slack_clacks.configuration.cli import add_context_argument
 from slack_clacks.configuration.database import (
     add_context,
     delete_context,
@@ -13,6 +14,7 @@ from slack_clacks.configuration.database import (
     get_context,
     get_current_context,
     get_session,
+    resolve_context,
     set_current_context,
     update_context,
 )
@@ -122,11 +124,7 @@ def handle_status(args: argparse.Namespace) -> None:
 
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         client = create_client(context.access_token, context.app_type)
 
@@ -305,6 +303,7 @@ def generate_cli() -> argparse.ArgumentParser:
         default=None,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(status_parser)
     status_parser.add_argument(
         "-o",
         "--outfile",

--- a/src/slack_clacks/configuration/cli.py
+++ b/src/slack_clacks/configuration/cli.py
@@ -16,6 +16,24 @@ from slack_clacks.configuration.database import (
 )
 
 
+def add_context_argument(parser: argparse.ArgumentParser) -> None:
+    """Attach the shared ``-C/--context`` override flag.
+
+    When provided, the named context overrides the active context for this
+    single command invocation, without changing which context is active.
+    """
+    parser.add_argument(
+        "-C",
+        "--context",
+        type=str,
+        default=None,
+        help=(
+            "Context to act against, overriding the active context "
+            "for this command only"
+        ),
+    )
+
+
 def handle_init(args: argparse.Namespace) -> None:
     config_dir = args.config_dir
     ensure_db_updated(config_dir=config_dir)

--- a/src/slack_clacks/configuration/database.py
+++ b/src/slack_clacks/configuration/database.py
@@ -163,6 +163,31 @@ def get_current_context(session: Session) -> Context | None:
     return get_context(session, current_entry.context_name)
 
 
+def resolve_context(session: Session, name: str | None = None) -> Context:
+    """Resolve the context a command should operate against.
+
+    If ``name`` is provided (e.g. from a ``--context`` override), that named
+    context is used instead of the active one; it must exist. Otherwise the
+    current active context is used. Raises ``ValueError`` when no usable
+    context can be found.
+    """
+    if name is not None:
+        context = get_context(session, name)
+        if context is None:
+            raise ValueError(
+                f"Context '{name}' does not exist. "
+                "List contexts with: clacks config contexts"
+            )
+        return context
+
+    context = get_current_context(session)
+    if context is None:
+        raise ValueError(
+            "No active authentication context. Authenticate with: clacks auth login"
+        )
+    return context
+
+
 def delete_context(session: Session, name: str) -> None:
     """Delete a context from the database."""
     context = get_context(session, name)

--- a/src/slack_clacks/files/cli.py
+++ b/src/slack_clacks/files/cli.py
@@ -10,10 +10,11 @@ from typing import cast
 
 from slack_clacks.auth.client import create_client
 from slack_clacks.auth.validation import get_scopes_for_mode, validate
+from slack_clacks.configuration.cli import add_context_argument
 from slack_clacks.configuration.database import (
     ensure_db_updated,
-    get_current_context,
     get_session,
+    resolve_context,
 )
 from slack_clacks.files.operations import (
     download_file_to_path,
@@ -29,11 +30,7 @@ from slack_clacks.upload.cli import generate_upload_parser
 def handle_download(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         scopes = get_scopes_for_mode(context.app_type)
         validate("files:read", scopes, raise_on_error=True)
@@ -86,11 +83,7 @@ def handle_download(args: argparse.Namespace) -> None:
 def handle_list(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         scopes = get_scopes_for_mode(context.app_type)
         validate("files:read", scopes, raise_on_error=True)
@@ -115,11 +108,7 @@ def handle_list(args: argparse.Namespace) -> None:
 def handle_info(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         scopes = get_scopes_for_mode(context.app_type)
         validate("files:read", scopes, raise_on_error=True)
@@ -147,6 +136,7 @@ def generate_files_cli() -> argparse.ArgumentParser:
         default=None,
         help="Configuration directory",
     )
+    add_context_argument(dl_parser)
     id_group = dl_parser.add_mutually_exclusive_group(required=True)
     id_group.add_argument(
         "-i",
@@ -182,6 +172,7 @@ def generate_files_cli() -> argparse.ArgumentParser:
         default=None,
         help="Configuration directory",
     )
+    add_context_argument(list_parser)
     list_parser.add_argument(
         "-c",
         "--channel",
@@ -219,6 +210,7 @@ def generate_files_cli() -> argparse.ArgumentParser:
         default=None,
         help="Configuration directory",
     )
+    add_context_argument(info_parser)
     info_parser.add_argument(
         "-i",
         "--file-id",

--- a/src/slack_clacks/listen/cli.py
+++ b/src/slack_clacks/listen/cli.py
@@ -7,10 +7,11 @@ import json
 import sys
 
 from slack_clacks.auth.client import create_client
+from slack_clacks.configuration.cli import add_context_argument
 from slack_clacks.configuration.database import (
     ensure_db_updated,
-    get_current_context,
     get_session,
+    resolve_context,
 )
 from slack_clacks.listen.operations import listen_channel
 from slack_clacks.messaging.operations import (
@@ -22,11 +23,7 @@ from slack_clacks.messaging.operations import (
 def handle_listen(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         client = create_client(context.access_token, context.app_type)
 
@@ -91,6 +88,7 @@ def generate_listen_parser() -> argparse.ArgumentParser:
         type=str,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(parser)
     parser.add_argument(
         "--thread",
         dest="thread_ts",

--- a/src/slack_clacks/messaging/cli.py
+++ b/src/slack_clacks/messaging/cli.py
@@ -6,10 +6,11 @@ from typing import Any
 
 from slack_clacks.auth.client import create_client
 from slack_clacks.auth.validation import get_scopes_for_mode, validate
+from slack_clacks.configuration.cli import add_context_argument
 from slack_clacks.configuration.database import (
     ensure_db_updated,
-    get_current_context,
     get_session,
+    resolve_context,
 )
 from slack_clacks.constants import SLACK_TS_EPSILON
 from slack_clacks.messaging.operations import (
@@ -90,11 +91,7 @@ def _resolve_target_channel(
 def handle_send(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         client = create_client(context.access_token, context.app_type)
         channel_id = _resolve_target_channel(client, args, session, context.name)
@@ -116,6 +113,7 @@ def generate_send_parser() -> argparse.ArgumentParser:
         type=str,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(parser)
     parser.add_argument(
         "-c",
         "--channel",
@@ -156,11 +154,7 @@ def generate_send_parser() -> argparse.ArgumentParser:
 def handle_schedule(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         client = create_client(context.access_token, context.app_type)
         channel_id = _resolve_target_channel(client, args, session, context.name)
@@ -185,6 +179,7 @@ def generate_schedule_parser() -> argparse.ArgumentParser:
         type=str,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(parser)
     parser.add_argument(
         "-c",
         "--channel",
@@ -235,11 +230,7 @@ def generate_schedule_parser() -> argparse.ArgumentParser:
 def handle_read(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         client = create_client(context.access_token, context.app_type)
 
@@ -310,6 +301,7 @@ def generate_read_parser() -> argparse.ArgumentParser:
         type=str,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(parser)
     parser.add_argument(
         "-c",
         "--channel",
@@ -396,11 +388,7 @@ def generate_read_parser() -> argparse.ArgumentParser:
 def handle_recent(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         scopes = get_scopes_for_mode(context.app_type)
         validate("channels:history", scopes, raise_on_error=True)
@@ -426,6 +414,7 @@ def generate_recent_parser() -> argparse.ArgumentParser:
         type=str,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(parser)
     parser.add_argument(
         "-l",
         "--limit",
@@ -449,11 +438,7 @@ def generate_recent_parser() -> argparse.ArgumentParser:
 def handle_react(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         client = create_client(context.access_token, context.app_type)
         channel_id = _resolve_target_channel(client, args, session, context.name)
@@ -480,6 +465,7 @@ def generate_react_parser() -> argparse.ArgumentParser:
         type=str,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(parser)
 
     target_group = parser.add_mutually_exclusive_group(required=True)
     target_group.add_argument(
@@ -528,11 +514,7 @@ def generate_react_parser() -> argparse.ArgumentParser:
 def handle_search(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         scopes = get_scopes_for_mode(context.app_type)
         validate("search:read", scopes, raise_on_error=True)
@@ -591,6 +573,7 @@ examples:
         type=str,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(parser)
     parser.add_argument(
         "-q",
         "--query",
@@ -654,11 +637,7 @@ examples:
 def handle_delete(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         client = create_client(context.access_token, context.app_type)
         channel_id = _resolve_target_channel(client, args, session, context.name)
@@ -684,6 +663,7 @@ def generate_delete_parser() -> argparse.ArgumentParser:
         type=str,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(parser)
 
     target_group = parser.add_mutually_exclusive_group(required=True)
     target_group.add_argument(

--- a/src/slack_clacks/rolodex/cli.py
+++ b/src/slack_clacks/rolodex/cli.py
@@ -8,10 +8,11 @@ import sys
 from pathlib import Path
 
 from slack_clacks.auth.client import create_client
+from slack_clacks.configuration.cli import add_context_argument
 from slack_clacks.configuration.database import (
     ensure_db_updated,
-    get_current_context,
     get_session,
+    resolve_context,
 )
 from slack_clacks.rolodex.data import PLATFORM_TARGET_TYPES
 from slack_clacks.rolodex.operations import (
@@ -26,11 +27,7 @@ from slack_clacks.rolodex.operations import (
 def handle_add(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         alias_obj = add_alias(
             session,
@@ -56,11 +53,7 @@ def handle_add(args: argparse.Namespace) -> None:
 def handle_list(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         aliases = list_aliases(
             session,
@@ -91,11 +84,7 @@ def handle_list(args: argparse.Namespace) -> None:
 def handle_remove(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         removed = remove_alias(
             session,
@@ -116,11 +105,7 @@ def handle_remove(args: argparse.Namespace) -> None:
 def handle_sync(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         client = create_client(context.access_token, context.app_type)
         result = sync_from_slack(session, client, context.name)
@@ -165,6 +150,7 @@ def generate_cli() -> argparse.ArgumentParser:
         default=None,
         help="Configuration directory",
     )
+    add_context_argument(add_parser)
     add_parser.add_argument(
         "alias",
         type=str,
@@ -209,6 +195,7 @@ def generate_cli() -> argparse.ArgumentParser:
         default=None,
         help="Configuration directory",
     )
+    add_context_argument(list_parser)
     list_parser.add_argument(
         "-p",
         "--platform",
@@ -258,6 +245,7 @@ def generate_cli() -> argparse.ArgumentParser:
         default=None,
         help="Configuration directory",
     )
+    add_context_argument(remove_parser)
     remove_parser.add_argument(
         "alias",
         type=str,
@@ -288,6 +276,7 @@ def generate_cli() -> argparse.ArgumentParser:
         default=None,
         help="Configuration directory",
     )
+    add_context_argument(sync_parser)
     sync_parser.add_argument(
         "-o",
         "--outfile",

--- a/src/slack_clacks/upload/cli.py
+++ b/src/slack_clacks/upload/cli.py
@@ -7,10 +7,11 @@ import sys
 
 from slack_clacks.auth.client import create_client
 from slack_clacks.auth.validation import get_scopes_for_mode, validate
+from slack_clacks.configuration.cli import add_context_argument
 from slack_clacks.configuration.database import (
     ensure_db_updated,
-    get_current_context,
     get_session,
+    resolve_context,
 )
 from slack_clacks.messaging.operations import (
     open_dm_channel,
@@ -48,11 +49,7 @@ def _copy_to_clipboard(text: str) -> None:
 def handle_upload(args: argparse.Namespace) -> None:
     ensure_db_updated(config_dir=args.config_dir)
     with get_session(args.config_dir) as session:
-        context = get_current_context(session)
-        if context is None:
-            raise ValueError(
-                "No active authentication context. Authenticate with: clacks auth login"
-            )
+        context = resolve_context(session, args.context)
 
         scopes = get_scopes_for_mode(context.app_type)
         validate("files:write", scopes, raise_on_error=True)
@@ -143,6 +140,7 @@ def generate_upload_parser() -> argparse.ArgumentParser:
         type=str,
         help="Configuration directory (default: platform-specific user config dir)",
     )
+    add_context_argument(parser)
 
     target_group = parser.add_mutually_exclusive_group()
     target_group.add_argument(

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -65,11 +65,12 @@ class TestHandleDownloadScopeValidation(unittest.TestCase):
         mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
         with patch(
-            "slack_clacks.files.cli.get_current_context",
+            "slack_clacks.files.cli.resolve_context",
             return_value=mock_context,
         ):
             args = argparse.Namespace(
                 config_dir=None,
+                context=None,
                 file_id="F123",
                 permalink=None,
                 write=None,
@@ -103,11 +104,12 @@ class TestHandleInfo(unittest.TestCase):
         }
 
         with patch(
-            "slack_clacks.files.cli.get_current_context",
+            "slack_clacks.files.cli.resolve_context",
             return_value=mock_context,
         ):
             args = argparse.Namespace(
                 config_dir=None,
+                context=None,
                 file_id="F123",
             )
 
@@ -143,11 +145,12 @@ class TestHandleList(unittest.TestCase):
         }
 
         with patch(
-            "slack_clacks.files.cli.get_current_context",
+            "slack_clacks.files.cli.resolve_context",
             return_value=mock_context,
         ):
             args = argparse.Namespace(
                 config_dir=None,
+                context=None,
                 channel=None,
                 user=None,
                 limit=20,
@@ -198,11 +201,12 @@ class TestHandleList(unittest.TestCase):
         mock_list_files.return_value = {"ok": True, "files": []}
 
         with patch(
-            "slack_clacks.files.cli.get_current_context",
+            "slack_clacks.files.cli.resolve_context",
             return_value=mock_context,
         ):
             args = argparse.Namespace(
                 config_dir=None,
+                context=None,
                 channel="general",
                 user="@alice",
                 limit=5,

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -72,7 +72,7 @@ class TestHandleUploadWithFile(unittest.TestCase):
         mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
         ctx_patch = patch(
-            "slack_clacks.upload.cli.get_current_context",
+            "slack_clacks.upload.cli.resolve_context",
             return_value=mock_context,
         )
         with ctx_patch:
@@ -85,6 +85,7 @@ class TestHandleUploadWithFile(unittest.TestCase):
             outfile = io.StringIO()
             args = argparse.Namespace(
                 config_dir=None,
+                context=None,
                 channel="general",
                 user=None,
                 file="/tmp/test.py",
@@ -134,7 +135,7 @@ class TestHandleUploadWithStdin(unittest.TestCase):
         mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
         ctx_patch = patch(
-            "slack_clacks.upload.cli.get_current_context",
+            "slack_clacks.upload.cli.resolve_context",
             return_value=mock_context,
         )
         with ctx_patch:
@@ -147,6 +148,7 @@ class TestHandleUploadWithStdin(unittest.TestCase):
             outfile = io.StringIO()
             args = argparse.Namespace(
                 config_dir=None,
+                context=None,
                 channel="ops",
                 user=None,
                 file=None,
@@ -187,12 +189,13 @@ class TestHandleUploadScopeValidation(unittest.TestCase):
         mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
         ctx_patch = patch(
-            "slack_clacks.upload.cli.get_current_context",
+            "slack_clacks.upload.cli.resolve_context",
             return_value=mock_context,
         )
         with ctx_patch:
             args = argparse.Namespace(
                 config_dir=None,
+                context=None,
                 channel="general",
                 user=None,
                 file="/tmp/test.py",
@@ -230,7 +233,7 @@ class TestHandleUploadDefaultFilename(unittest.TestCase):
         mock_get_session.return_value.__exit__ = MagicMock(return_value=False)
 
         ctx_patch = patch(
-            "slack_clacks.upload.cli.get_current_context",
+            "slack_clacks.upload.cli.resolve_context",
             return_value=mock_context,
         )
         with ctx_patch:
@@ -239,6 +242,7 @@ class TestHandleUploadDefaultFilename(unittest.TestCase):
             outfile = io.StringIO()
             args = argparse.Namespace(
                 config_dir=None,
+                context=None,
                 channel=None,
                 user=None,
                 file=None,

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.10.0"
+version = "0.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.10.3"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

Adds a shared `-C/--context` flag to every command that operates against a clacks context. When given, the named context overrides the active context for that single invocation — without changing which context is active (no `config switch` needed).

## What changed

- **`resolve_context(session, name)`** (`configuration/database.py`): centralizes the override-or-current lookup and the not-found / no-active-context errors, collapsing the repeated `get_current_context` + None-check block that was duplicated across every handler.
- **`add_context_argument(parser)`** (`configuration/cli.py`): registers the flag consistently. Uses `-C` (matching `config switch`) to avoid colliding with `-c/--channel` in messaging/files/upload.
- Wired into: messaging (send, schedule, read, recent, react, search, delete), files (download, list, info), upload, listen, rolodex (add, list, remove, sync), and auth status.
- Tests repointed from patching `get_current_context` to `resolve_context`.
- Version bumped `0.10.3` → `0.11.0` (backward-compatible feature).

## Behavior

```
clacks read -c '#general' --context other-workspace   # acts as other-workspace, active context unchanged
clacks read -c '#general' --context does-not-exist     # ValueError: Context 'does-not-exist' does not exist. List contexts with: clacks config contexts
```