### PR TITLE
Clarify --order help: client-side, single-page sort

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.12.0"
+version = "0.12.1"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/messaging/cli.py
+++ b/src/slack_clacks/messaging/cli.py
@@ -53,12 +53,12 @@ def sort_messages_by_ts(messages: list, order: str) -> list:
 def add_order_argument(parser: argparse.ArgumentParser) -> None:
     """Attach the shared ``--order {asc,desc}`` flag.
 
-    A client-side, post-fetch re-sort of the messages already in the
-    response. It does not change which messages Slack returns, and it
-    sorts only the current page of results, not across paginated
-    requests. ``desc`` (default) is newest-first (Slack's native return
-    order); ``asc`` is oldest-first — convenient for agentic loops that
-    consume oldest-first.
+    The flag re-sorts the fetched messages by timestamp before printing.
+    It is client-side and display-only: it does not change which messages
+    Slack returns, and it orders only the output of a single invocation
+    (separate pages or invocations are not merged). ``desc`` (default) is
+    newest-first; ``asc`` is oldest-first — convenient for agentic loops
+    that consume oldest-first.
     """
     parser.add_argument(
         "--order",
@@ -66,11 +66,11 @@ def add_order_argument(parser: argparse.ArgumentParser) -> None:
         choices=("asc", "desc"),
         default="desc",
         help=(
-            "Re-sort the messages in this response by timestamp before "
-            "printing. Client-side only: does not change which messages "
-            "Slack returns, and sorts only the current page of results, "
-            "not across pages. 'desc' (default) is newest-first (Slack's "
-            "native order); 'asc' is oldest-first."
+            "Re-sort the fetched messages by timestamp before printing. "
+            "Client-side only: does not change which messages Slack "
+            "returns, and orders only this command's output (separate "
+            "pages are not merged). 'desc' (default) is newest-first; "
+            "'asc' is oldest-first."
         ),
     )
 
@@ -629,8 +629,9 @@ examples:
         choices=["timestamp", "score"],
         default="timestamp",
         help=(
-            "Slack-side ranking: sort results by timestamp or relevance "
-            "score (default: timestamp)"
+            "Slack-side ranking: timestamp or relevance score (default: "
+            "timestamp). Chooses which results each page contains; "
+            "printed order is still controlled by --order."
         ),
     )
     parser.add_argument(

--- a/src/slack_clacks/messaging/cli.py
+++ b/src/slack_clacks/messaging/cli.py
@@ -53,9 +53,12 @@ def sort_messages_by_ts(messages: list, order: str) -> list:
 def add_order_argument(parser: argparse.ArgumentParser) -> None:
     """Attach the shared ``--order {asc,desc}`` flag.
 
-    Default ``desc`` preserves Slack's native reverse-chronological return
-    order. ``asc`` re-sorts the returned messages locally before printing
-    — convenient for agentic loops that consume oldest-first.
+    A client-side, post-fetch re-sort of the messages already in the
+    response. It does not change which messages Slack returns, and it
+    sorts only the current page of results, not across paginated
+    requests. ``desc`` (default) is newest-first (Slack's native return
+    order); ``asc`` is oldest-first — convenient for agentic loops that
+    consume oldest-first.
     """
     parser.add_argument(
         "--order",
@@ -63,9 +66,11 @@ def add_order_argument(parser: argparse.ArgumentParser) -> None:
         choices=("asc", "desc"),
         default="desc",
         help=(
-            "Order returned messages by timestamp. "
-            "'desc' (default) preserves Slack's newest-first order; "
-            "'asc' re-sorts locally to oldest-first before printing."
+            "Re-sort the messages in this response by timestamp before "
+            "printing. Client-side only: does not change which messages "
+            "Slack returns, and sorts only the current page of results, "
+            "not across pages. 'desc' (default) is newest-first (Slack's "
+            "native order); 'asc' is oldest-first."
         ),
     )
 
@@ -623,14 +628,17 @@ examples:
         type=str,
         choices=["timestamp", "score"],
         default="timestamp",
-        help="Sort results by timestamp or relevance score (default: timestamp)",
+        help=(
+            "Slack-side ranking: sort results by timestamp or relevance "
+            "score (default: timestamp)"
+        ),
     )
     parser.add_argument(
         "--sort-dir",
         type=str,
         choices=["asc", "desc"],
         default="desc",
-        help="Sort direction (default: desc)",
+        help="Slack-side sort direction (default: desc)",
     )
     parser.add_argument(
         "-l",

--- a/src/slack_clacks/skill/content.py
+++ b/src/slack_clacks/skill/content.py
@@ -153,8 +153,9 @@ Supported query filters (included in the `-q` string):
 - `-word` - exclude messages containing a word
 
 Options:
-- `-s, --sort` - Sort by `timestamp` (default) or `score` (relevance)
-- `--sort-dir` - Sort direction: `asc` or `desc` (default)
+- `-s, --sort` - Sort by `timestamp` (default) or `score` (relevance) (Slack-side)
+- `--sort-dir` - Sort direction: `asc` or `desc` (default) (Slack-side)
+- `--order` - Re-sort output client-side: `asc` or `desc` (default)
 - `-l, --limit` - Results per page, 1-100 (default: 20)
 - `--page` / `--cursor` - Pagination (mutually exclusive)
 

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Closes #87.

## Problem

The `--order {asc,desc}` flag (shared by `read`, `recent`, `search`) is a client-side, post-fetch re-sort, but its help didn't say so: `desc` read like a no-op, nothing stated the flag never changes which messages Slack returns, and `search`'s server-side `--sort`/`--sort-dir` were indistinguishable from the client-side `--order`.

## Fix (help strings/docstrings only — no behavior change)

- `--order` help (all three commands): "Re-sort the fetched messages by timestamp before printing. Client-side only: does not change which messages Slack returns, and orders only this command's output (separate pages are not merged). 'desc' (default) is newest-first; 'asc' is oldest-first."
- `search --sort`: "Slack-side ranking: timestamp or relevance score (default: timestamp). Chooses which results each page contains; printed order is still controlled by --order."
- `search --sort-dir`: "Slack-side sort direction (default: desc)."
- `add_order_argument` docstring rewritten to match.
- Skill content: "(Slack-side)" tags on the `--sort`/`--sort-dir` lines and a one-line client-side `--order` entry.
- Version bumped to 0.12.1.

Note: the issue's proposed wording included "'desc' … (Slack's native order)" — review found that claim false for thread reads (`conversations.replies` returns parent-first/oldest-first), for `recent` (its list is aggregated and sorted locally), and for `search` off-defaults, so it was dropped rather than copied through.

## Review process

Implemented and then iterated under two rounds of four independent adversarial reviews. Round 1 findings (false native-order claim, missing `--sort`/`--order` precedence, phrasing that misdescribed `recent`, skill-content ambiguity) were fixed; round 2 returned four independent "no findings above NIT" verdicts, each verifying every claim in the final text against all modes of all three commands.

Possible follow-up surfaced during review (pre-existing, out of scope): `--sort score` ranking can never appear in printed output because `--order` re-sorts unconditionally — an `--order none` passthrough could be a future enhancement.

## Checks

`ruff check`, `ruff format --check`, `mypy src/`, 138 unittests — all pass. All three `--help` outputs and the rendered SKILL_MD verified.