### PR TITLE
recent: paginate users.conversations until cursor exhausted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.13.0"
+version = "0.12.2"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.12.0"
+version = "0.13.0"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/listen/operations.py
+++ b/src/slack_clacks/listen/operations.py
@@ -9,32 +9,9 @@ from decimal import Decimal
 from typing import Any
 
 from slack_sdk import WebClient
-from slack_sdk.errors import SlackApiError
 
 from slack_clacks.constants import SLACK_TS_EPSILON
-
-
-def _call_with_backoff(
-    func: Any,
-    max_retries: int = 5,
-    base_delay: float = 1.0,
-    **kwargs: Any,
-) -> Any:
-    """Call a Slack API function with exponential backoff on rate limit."""
-    for attempt in range(max_retries):
-        try:
-            return func(**kwargs)
-        except SlackApiError as e:
-            if e.response.get("error") == "ratelimited":
-                if attempt == max_retries - 1:
-                    raise
-                # Get retry-after header or use exponential backoff
-                retry_after = int(e.response.headers.get("Retry-After", 0))
-                delay = max(retry_after, base_delay * (2**attempt))
-                time.sleep(delay)
-            else:
-                raise
-    return None  # Should never reach here
+from slack_clacks.messaging.operations import call_with_backoff
 
 
 def listen_channel(
@@ -69,7 +46,7 @@ def listen_channel(
     if include_history > 0:
         messages: list[Any]
         if thread_ts:
-            response = _call_with_backoff(
+            response = call_with_backoff(
                 client.conversations_replies,
                 channel=channel_id,
                 ts=thread_ts,
@@ -82,7 +59,7 @@ def listen_channel(
             else:
                 messages = []
         else:
-            response = _call_with_backoff(
+            response = call_with_backoff(
                 client.conversations_history,
                 channel=channel_id,
                 limit=include_history,
@@ -117,7 +94,7 @@ def listen_channel(
         exclusive_oldest = str(Decimal(latest_ts) + SLACK_TS_EPSILON)
 
         if thread_ts:
-            response = _call_with_backoff(
+            response = call_with_backoff(
                 client.conversations_replies,
                 channel=channel_id,
                 ts=thread_ts,
@@ -131,7 +108,7 @@ def listen_channel(
                 if m.get("ts") != thread_ts and m.get("ts", "") > latest_ts
             ]
         else:
-            response = _call_with_backoff(
+            response = call_with_backoff(
                 client.conversations_history,
                 channel=channel_id,
                 oldest=exclusive_oldest,

--- a/src/slack_clacks/messaging/cli.py
+++ b/src/slack_clacks/messaging/cli.py
@@ -435,7 +435,11 @@ def handle_recent(args: argparse.Namespace) -> None:
 
 def generate_recent_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Show recent messages across all conversations",
+        description=(
+            "Show recent messages across all conversations "
+            "(makes one history request per conversation; "
+            "conversations whose fetch fails are skipped)"
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 

--- a/src/slack_clacks/messaging/operations.py
+++ b/src/slack_clacks/messaging/operations.py
@@ -285,18 +285,36 @@ def read_thread(
 
 
 def get_recent_activity(
-    client: WebClient, conversation_limit: int = 100, message_limit: int = 20
+    client: WebClient, conversation_limit: int = 200, message_limit: int = 20
 ):
     """
     Get recent messages across all user's conversations.
     Returns a list of messages with their conversation context, sorted by timestamp.
+
+    ``conversation_limit`` is the per-page size for ``users_conversations``;
+    pages are followed via ``response_metadata.next_cursor`` until exhausted,
+    so every conversation is enumerated regardless of how many there are.
+    Slack caps pages at 200 on standard tiers (hence the default), so the
+    value only affects request count, never completeness. There is
+    deliberately no total cap: one would silently drop conversations, which
+    is exactly the bug this pagination exists to fix.
     """
-    conversations_response = client.users_conversations(
-        types="public_channel,private_channel,mpim,im", limit=conversation_limit
-    )
+    channels = []
+    cursor: str | None = None
+    while True:
+        response = client.users_conversations(
+            types="public_channel,private_channel,mpim,im",
+            limit=conversation_limit,
+            cursor=cursor,
+        )
+        channels.extend(response["channels"])
+        response_metadata = response.get("response_metadata")
+        cursor = response_metadata.get("next_cursor") if response_metadata else None
+        if not cursor:
+            break
 
     all_messages = []
-    for channel in conversations_response["channels"]:
+    for channel in channels:
         try:
             history_response = client.conversations_history(
                 channel=channel["id"], limit=1

--- a/src/slack_clacks/messaging/operations.py
+++ b/src/slack_clacks/messaging/operations.py
@@ -18,6 +18,29 @@ from slack_clacks.messaging.exceptions import (
 )
 
 
+def call_with_backoff(
+    func: Any,
+    max_retries: int = 5,
+    base_delay: float = 1.0,
+    **kwargs: Any,
+) -> Any:
+    """Call a Slack API function with exponential backoff on rate limit."""
+    for attempt in range(max_retries):
+        try:
+            return func(**kwargs)
+        except SlackApiError as e:
+            if e.response.get("error") == "ratelimited":
+                if attempt == max_retries - 1:
+                    raise
+                # Get retry-after header or use exponential backoff
+                retry_after = int(e.response.headers.get("Retry-After", 0))
+                delay = max(retry_after, base_delay * (2**attempt))
+                time.sleep(delay)
+            else:
+                raise
+    return None  # Should never reach here
+
+
 def resolve_channel_id(
     client: WebClient,
     channel_identifier: str,
@@ -285,26 +308,30 @@ def read_thread(
 
 
 def get_recent_activity(
-    client: WebClient, conversation_limit: int = 200, message_limit: int = 20
+    client: WebClient, conversations_page_size: int = 200, message_limit: int = 20
 ):
     """
     Get recent messages across all user's conversations.
     Returns a list of messages with their conversation context, sorted by timestamp.
 
-    ``conversation_limit`` is the per-page size for ``users_conversations``;
-    pages are followed via ``response_metadata.next_cursor`` until exhausted,
-    so every conversation is enumerated regardless of how many there are.
-    Slack caps pages at 200 on standard tiers (hence the default), so the
-    value only affects request count, never completeness. There is
-    deliberately no total cap: one would silently drop conversations, which
-    is exactly the bug this pagination exists to fix.
+    Every conversation is enumerated via ``users_conversations`` cursor
+    pagination, with ``conversations_page_size`` as the per-page size. Slack
+    recommends pages of at most 200 (hence the default); the loop runs until
+    next_cursor is exhausted, so the value affects request count, not
+    completeness.
+
+    The function then makes one ``conversations_history`` call per
+    conversation, so runtime scales with the number of conversations.
+    Rate-limited history calls are retried with backoff, but calls that
+    ultimately fail (including persistent rate limiting after retries) are
+    skipped, so the output can omit conversations.
     """
     channels = []
     cursor: str | None = None
     while True:
         response = client.users_conversations(
             types="public_channel,private_channel,mpim,im",
-            limit=conversation_limit,
+            limit=conversations_page_size,
             cursor=cursor,
         )
         channels.extend(response["channels"])
@@ -316,8 +343,10 @@ def get_recent_activity(
     all_messages = []
     for channel in channels:
         try:
-            history_response = client.conversations_history(
-                channel=channel["id"], limit=1
+            history_response = call_with_backoff(
+                client.conversations_history,
+                channel=channel["id"],
+                limit=1,
             )
             if history_response["messages"]:
                 for message in history_response["messages"]:

--- a/tests/test_listen.py
+++ b/tests/test_listen.py
@@ -272,49 +272,5 @@ class TestContinuousMode(unittest.TestCase):
         self.assertEqual(len(messages), 2)
 
 
-class TestRateLimitHandling(unittest.TestCase):
-    def setUp(self):
-        self.client = MagicMock()
-
-    def test_retries_on_rate_limit(self):
-        """Should retry with backoff when rate limited."""
-        from slack_sdk.errors import SlackApiError
-
-        from slack_clacks.messaging.operations import call_with_backoff
-
-        mock_response = MagicMock()
-        mock_response.get.return_value = "ratelimited"
-        mock_response.headers = {"Retry-After": "0"}
-
-        call_count = 0
-
-        def mock_func(**kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count < 3:
-                raise SlackApiError("rate limited", mock_response)
-            return {"messages": []}
-
-        result = call_with_backoff(mock_func, max_retries=5, base_delay=0.01)
-        self.assertEqual(call_count, 3)
-        self.assertEqual(result, {"messages": []})
-
-    def test_raises_after_max_retries(self):
-        """Should raise after max retries exhausted."""
-        from slack_sdk.errors import SlackApiError
-
-        from slack_clacks.messaging.operations import call_with_backoff
-
-        mock_response = MagicMock()
-        mock_response.get.return_value = "ratelimited"
-        mock_response.headers = {"Retry-After": "0"}
-
-        def mock_func(**kwargs):
-            raise SlackApiError("rate limited", mock_response)
-
-        with self.assertRaises(SlackApiError):
-            call_with_backoff(mock_func, max_retries=2, base_delay=0.01)
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_listen.py
+++ b/tests/test_listen.py
@@ -280,7 +280,7 @@ class TestRateLimitHandling(unittest.TestCase):
         """Should retry with backoff when rate limited."""
         from slack_sdk.errors import SlackApiError
 
-        from slack_clacks.listen.operations import _call_with_backoff
+        from slack_clacks.messaging.operations import call_with_backoff
 
         mock_response = MagicMock()
         mock_response.get.return_value = "ratelimited"
@@ -295,7 +295,7 @@ class TestRateLimitHandling(unittest.TestCase):
                 raise SlackApiError("rate limited", mock_response)
             return {"messages": []}
 
-        result = _call_with_backoff(mock_func, max_retries=5, base_delay=0.01)
+        result = call_with_backoff(mock_func, max_retries=5, base_delay=0.01)
         self.assertEqual(call_count, 3)
         self.assertEqual(result, {"messages": []})
 
@@ -303,7 +303,7 @@ class TestRateLimitHandling(unittest.TestCase):
         """Should raise after max retries exhausted."""
         from slack_sdk.errors import SlackApiError
 
-        from slack_clacks.listen.operations import _call_with_backoff
+        from slack_clacks.messaging.operations import call_with_backoff
 
         mock_response = MagicMock()
         mock_response.get.return_value = "ratelimited"
@@ -313,7 +313,7 @@ class TestRateLimitHandling(unittest.TestCase):
             raise SlackApiError("rate limited", mock_response)
 
         with self.assertRaises(SlackApiError):
-            _call_with_backoff(mock_func, max_retries=2, base_delay=0.01)
+            call_with_backoff(mock_func, max_retries=2, base_delay=0.01)
 
 
 if __name__ == "__main__":

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1,9 +1,12 @@
 import unittest
 from datetime import datetime as real_datetime
 from datetime import timedelta, timezone
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+from slack_sdk.errors import SlackApiError
 
 from slack_clacks.messaging.operations import (
+    call_with_backoff,
     parse_schedule_time,
     parse_timestamp,
     resolve_message_timestamp,
@@ -333,6 +336,39 @@ class TestParseScheduleTime(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             parse_schedule_time("next tuesday")
         self.assertIn("Unrecognized", str(ctx.exception))
+
+
+class TestCallWithBackoff(unittest.TestCase):
+    def test_retries_on_rate_limit(self):
+        """Should retry with backoff when rate limited."""
+        mock_response = MagicMock()
+        mock_response.get.return_value = "ratelimited"
+        mock_response.headers = {"Retry-After": "0"}
+
+        call_count = 0
+
+        def mock_func(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise SlackApiError("rate limited", mock_response)
+            return {"messages": []}
+
+        result = call_with_backoff(mock_func, max_retries=5, base_delay=0.01)
+        self.assertEqual(call_count, 3)
+        self.assertEqual(result, {"messages": []})
+
+    def test_raises_after_max_retries(self):
+        """Should raise after max retries exhausted."""
+        mock_response = MagicMock()
+        mock_response.get.return_value = "ratelimited"
+        mock_response.headers = {"Retry-After": "0"}
+
+        def mock_func(**kwargs):
+            raise SlackApiError("rate limited", mock_response)
+
+        with self.assertRaises(SlackApiError):
+            call_with_backoff(mock_func, max_retries=2, base_delay=0.01)
 
 
 if __name__ == "__main__":

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -1,5 +1,7 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+from slack_sdk.errors import SlackApiError
 
 from slack_clacks.messaging.operations import get_recent_activity
 
@@ -37,6 +39,11 @@ class TestGetRecentActivity(unittest.TestCase):
             for call in self.client.users_conversations.call_args_list
         ]
         self.assertEqual(cursors, [None, "cursor-2"])
+        for call in self.client.users_conversations.call_args_list:
+            self.assertEqual(call.kwargs["limit"], 200)
+            self.assertEqual(
+                call.kwargs["types"], "public_channel,private_channel,mpim,im"
+            )
 
     def test_terminates_when_response_metadata_missing(self):
         """A response without response_metadata ends the loop after one page."""
@@ -51,6 +58,25 @@ class TestGetRecentActivity(unittest.TestCase):
 
         self.assertEqual([m["channel_id"] for m in messages], ["C1"])
         self.assertEqual(self.client.users_conversations.call_count, 1)
+
+    def test_rate_limited_history_is_retried(self):
+        """A ratelimited conversations_history call is retried, not skipped."""
+        self.client.users_conversations.side_effect = [
+            {"channels": [{"id": "C1", "name": "one"}]},
+        ]
+        rate_limit_response = MagicMock()
+        rate_limit_response.get.return_value = "ratelimited"
+        rate_limit_response.headers = {"Retry-After": "0"}
+        self.client.conversations_history.side_effect = [
+            SlackApiError("rate limited", rate_limit_response),
+            {"messages": [{"ts": "100.000001", "text": "hi"}]},
+        ]
+
+        with patch("slack_clacks.messaging.operations.time.sleep"):
+            messages = get_recent_activity(self.client)
+
+        self.assertEqual([m["channel_id"] for m in messages], ["C1"])
+        self.assertEqual(self.client.conversations_history.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_recent.py
+++ b/tests/test_recent.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import MagicMock
+
+from slack_clacks.messaging.operations import get_recent_activity
+
+
+class TestGetRecentActivity(unittest.TestCase):
+    def setUp(self):
+        self.client = MagicMock()
+
+    def test_paginates_until_cursor_exhausted(self):
+        """Conversations from every page are considered, not just the first."""
+        self.client.users_conversations.side_effect = [
+            {
+                "channels": [{"id": "C1", "name": "one"}, {"id": "C2", "name": "two"}],
+                "response_metadata": {"next_cursor": "cursor-2"},
+            },
+            {
+                "channels": [{"id": "C3", "name": "three"}],
+                "response_metadata": {"next_cursor": ""},
+            },
+        ]
+        ts_by_channel = {"C1": "100.000001", "C2": "200.000001", "C3": "300.000001"}
+        self.client.conversations_history.side_effect = lambda channel, limit: {
+            "messages": [{"ts": ts_by_channel[channel], "text": f"in {channel}"}]
+        }
+
+        messages = get_recent_activity(self.client)
+
+        self.assertEqual(
+            {m["channel_id"] for m in messages},
+            {"C1", "C2", "C3"},
+        )
+        self.assertEqual(self.client.users_conversations.call_count, 2)
+        cursors = [
+            call.kwargs["cursor"]
+            for call in self.client.users_conversations.call_args_list
+        ]
+        self.assertEqual(cursors, [None, "cursor-2"])
+
+    def test_terminates_when_response_metadata_missing(self):
+        """A response without response_metadata ends the loop after one page."""
+        self.client.users_conversations.side_effect = [
+            {"channels": [{"id": "C1", "name": "one"}]},
+        ]
+        self.client.conversations_history.return_value = {
+            "messages": [{"ts": "100.000001", "text": "hi"}]
+        }
+
+        messages = get_recent_activity(self.client)
+
+        self.assertEqual([m["channel_id"] for m in messages], ["C1"])
+        self.assertEqual(self.client.users_conversations.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.13.0"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Closes #20.

## Problem

`clacks recent` fetched conversations with a single `users_conversations` call, so users with more conversations than one page (100) had the rest silently dropped — those conversations were never considered for recent activity.

## Fix

- `get_recent_activity` now enumerates ALL conversations by following `response_metadata.next_cursor` until exhausted, using the same loop shape as the existing `resolve_channel_id`/`resolve_user_id` pagination. The parameter is renamed `conversations_page_size` (it no longer limits anything; default raised to 200, Slack's recommended page maximum). No total cap — a cap would reintroduce the silent truncation this fixes.
- The per-conversation `conversations_history` fan-out — now unbounded by the same change — retries rate-limited calls with backoff: the backoff helper moved from `listen/operations.py` to `messaging/operations.py` under the public name `call_with_backoff` (listen imports it from there; behavior byte-identical, honors Retry-After). Calls that still fail after retries are skipped, as before.
- Docstring and `recent` CLI help disclose the contract honestly: enumeration is complete; one history call per conversation, so runtime scales with conversation count; persistently failing fetches are skipped, so output can omit conversations.
- Tests (`tests/test_recent.py`): pagination across pages with pinned request kwargs (`limit=200`, full `types` string) and cursor sequencing — fails against the old single-call code; termination without `response_metadata`; rate-limited history call retried (sleep patched). 141 tests total.
- Version 0.12.2 (sequenced after 0.12.1 in PR #89).

## Review process

Implemented, then iterated under two rounds of four independent adversarial reviews. Round 1's consensus MAJOR: unbounding enumeration unbounded the history fan-out, where `except Exception: continue` plus a retry-less client silently dropped rate-limited conversations — exactly the population this fix targets — while the docstring overclaimed completeness; also a fabricated "Slack caps pages at 200" claim. All fixed. Round 2: four independent "no findings above NIT" verdicts; three of the four ran mutation checks (backoff removed in-memory → retry test fails; pagination reverted → both pagination asserts fail) and verified the moved helper byte-equivalent, no import cycles, no `_call_with_backoff` remnants.

Known residue (recorded by reviewers as non-blocking): the `call_with_backoff` unit tests remain in `tests/test_listen.py` though the helper now lives in messaging.

## Checks

`ruff check`, `ruff format --check`, `mypy src/`, 141 unittests — all pass. Live-verified read-only (`uv run clacks recent -C fleet -l 5`) before review rounds.

Note for merge ordering: this PR and #89 both branch from 0.12.0; whichever merges second will need its version/lock conflict resolved (this one carries 0.12.2, #89 carries 0.12.1).