### PR TITLE
Fail fast on Slack rate limits: ClacksRateLimited, stderr hint, exit 75

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.12.2"
+version = "0.12.3"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.12.3"
+version = "0.13.0"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/__init__.py
+++ b/src/slack_clacks/__init__.py
@@ -1,7 +1,10 @@
 import sys
 from collections.abc import Sequence
 
+from slack_sdk.errors import SlackApiError
+
 from slack_clacks.cli import generate_cli
+from slack_clacks.exceptions import RATE_LIMIT_EXIT_CODE, ClacksRateLimited
 from slack_clacks.skill.status import check_skill_install_status
 
 
@@ -33,7 +36,14 @@ def main(argv: Sequence[str] | None = None) -> None:
     warn_if_skill_install_is_outdated(args_list)
     parser = generate_cli()
     args = parser.parse_args(args_list)
-    args.func(args)
+    try:
+        args.func(args)
+    except SlackApiError as error:
+        rate_limited = ClacksRateLimited.from_slack_error(error)
+        if rate_limited is None:
+            raise
+        print(rate_limited, file=sys.stderr)
+        sys.exit(RATE_LIMIT_EXIT_CODE)
 
 
 if __name__ == "__main__":

--- a/src/slack_clacks/auth/client.py
+++ b/src/slack_clacks/auth/client.py
@@ -1,5 +1,6 @@
 """
-Helper functions for creating properly configured Slack WebClients.
+Slack WebClient setup for clacks: the rate-limit-aware ClacksWebClient class
+and a factory for creating properly configured instances.
 """
 
 from typing import Any
@@ -15,9 +16,13 @@ from slack_clacks.exceptions import ClacksRateLimited
 class ClacksWebClient(WebClient):
     """WebClient that raises ClacksRateLimited on Slack rate limits.
 
-    Every SDK method helper funnels through ``api_call``, so translating here
-    makes rate limits surface as ClacksRateLimited (a SlackApiError subclass)
-    from any API call, with the Retry-After hint attached.
+    SDK method helpers funnel through ``api_call``, so translating here makes
+    rate limits surface as ClacksRateLimited (a SlackApiError subclass) from
+    API calls, with the Retry-After hint attached. Two paths bypass this:
+    SlackResponse cursor-iteration pagination raises raw SlackApiError (clacks
+    never iterates responses, and main()'s seam still converts those), and
+    ``files_upload_v2``'s file-bytes upload leg raises SlackRequestError,
+    outside the SlackApiError domain entirely.
     """
 
     def api_call(self, *args: Any, **kwargs: Any) -> SlackResponse:
@@ -30,7 +35,7 @@ class ClacksWebClient(WebClient):
             raise
 
 
-def create_client(access_token: str, app_type: str) -> WebClient:
+def create_client(access_token: str, app_type: str) -> ClacksWebClient:
     """
     Create a WebClient configured for the given app type.
 

--- a/src/slack_clacks/auth/client.py
+++ b/src/slack_clacks/auth/client.py
@@ -2,9 +2,32 @@
 Helper functions for creating properly configured Slack WebClients.
 """
 
+from typing import Any
+
 from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web import SlackResponse
 
 from slack_clacks.auth.constants import MODE_COOKIE
+from slack_clacks.exceptions import ClacksRateLimited
+
+
+class ClacksWebClient(WebClient):
+    """WebClient that raises ClacksRateLimited on Slack rate limits.
+
+    Every SDK method helper funnels through ``api_call``, so translating here
+    makes rate limits surface as ClacksRateLimited (a SlackApiError subclass)
+    from any API call, with the Retry-After hint attached.
+    """
+
+    def api_call(self, *args: Any, **kwargs: Any) -> SlackResponse:
+        try:
+            return super().api_call(*args, **kwargs)
+        except SlackApiError as error:
+            rate_limited = ClacksRateLimited.from_slack_error(error)
+            if rate_limited is not None and rate_limited is not error:
+                raise rate_limited from error
+            raise
 
 
 def create_client(access_token: str, app_type: str) -> WebClient:
@@ -16,15 +39,15 @@ def create_client(access_token: str, app_type: str) -> WebClient:
         app_type: Authentication mode (MODE_CLACKS, MODE_CLACKS_LITE, MODE_COOKIE)
 
     Returns:
-        Configured WebClient instance
+        Configured ClacksWebClient instance (raises ClacksRateLimited on 429s)
     """
     if app_type == MODE_COOKIE:
         if "|" in access_token:
             token, cookie = access_token.split("|", 1)
-            return WebClient(token=token, headers={"Cookie": f"d={cookie}"})
+            return ClacksWebClient(token=token, headers={"Cookie": f"d={cookie}"})
         else:
             raise ValueError(
                 "Cookie mode requires token in format: xoxc-token|d-cookie-value"
             )
 
-    return WebClient(token=access_token)
+    return ClacksWebClient(token=access_token)

--- a/src/slack_clacks/auth/cookie.py
+++ b/src/slack_clacks/auth/cookie.py
@@ -8,6 +8,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 from slack_clacks.auth.constants import MODE_COOKIE
+from slack_clacks.exceptions import ClacksRateLimited
 
 
 def authenticate_with_cookie(token: str, cookie: str) -> Dict[str, str]:
@@ -40,4 +41,6 @@ def authenticate_with_cookie(token: str, cookie: str) -> Dict[str, str]:
             "app_type": MODE_COOKIE,
         }
     except SlackApiError as e:
+        if ClacksRateLimited.from_slack_error(e) is not None:
+            raise
         raise Exception(f"Cookie authentication failed: {e.response['error']}")

--- a/src/slack_clacks/auth/oauth.py
+++ b/src/slack_clacks/auth/oauth.py
@@ -23,6 +23,7 @@ from slack_clacks.auth.constants import (
     OAUTH_PORT,
     REDIRECT_URI,
 )
+from slack_clacks.exceptions import ClacksRateLimited
 
 
 class OAuthCallbackHandler(http.server.BaseHTTPRequestHandler):
@@ -164,4 +165,6 @@ def start_oauth_flow(
             "app_type": mode,
         }
     except SlackApiError as e:
+        if ClacksRateLimited.from_slack_error(e) is not None:
+            raise
         raise Exception(f"Failed to exchange authorization code: {e.response['error']}")

--- a/src/slack_clacks/exceptions.py
+++ b/src/slack_clacks/exceptions.py
@@ -22,14 +22,21 @@ def rate_limit_retry_after(error: SlackApiError) -> int | None:
         if str(key).lower() != "retry-after":
             continue
         try:
-            return int(str(value).strip())
+            seconds = int(str(value).strip())
         except ValueError:
             continue
+        if seconds < 0:
+            continue
+        return seconds
     return None
 
 
 class ClacksRateLimited(Exception):
-    """Raised when Slack rate limits a request (HTTP 429 / "ratelimited")."""
+    """CLI-facing translation of a Slack rate limit (HTTP 429 / "ratelimited").
+
+    Carries the Retry-After hint and renders the user-facing message; it is
+    constructed from a SlackApiError rather than raised by API call sites.
+    """
 
     def __init__(self, retry_after: int | None = None) -> None:
         self.retry_after = retry_after
@@ -53,7 +60,7 @@ class ClacksRateLimited(Exception):
             return cls(retry_after=rate_limit_retry_after(error))
         try:
             error_code = response.get("error")
-        except (AttributeError, TypeError):
+        except (AttributeError, TypeError, ValueError):
             return None
         if error_code == "ratelimited":
             return cls(retry_after=rate_limit_retry_after(error))

--- a/src/slack_clacks/exceptions.py
+++ b/src/slack_clacks/exceptions.py
@@ -31,37 +31,48 @@ def rate_limit_retry_after(error: SlackApiError) -> int | None:
     return None
 
 
-class ClacksRateLimited(Exception):
-    """CLI-facing translation of a Slack rate limit (HTTP 429 / "ratelimited").
+class ClacksRateLimited(SlackApiError):
+    """A Slack rate limit (HTTP 429 / "ratelimited"), raised by ClacksWebClient.
 
-    Carries the Retry-After hint and renders the user-facing message; it is
-    constructed from a SlackApiError rather than raised by API call sites.
+    Subclasses SlackApiError so existing ``except SlackApiError`` sites
+    (retry loops, best-effort swallows) keep working unchanged; carries the
+    Retry-After hint and renders the user-facing message.
     """
 
-    def __init__(self, retry_after: int | None = None) -> None:
+    def __init__(self, retry_after: int | None = None, response: Any = None) -> None:
         self.retry_after = retry_after
+        self.response = response
         if retry_after is None:
-            message = "rate limited: retry later"
+            self.rate_limit_message = "rate limited: retry later"
         else:
-            message = f"rate limited: retry in {retry_after}s"
-        super().__init__(message)
+            self.rate_limit_message = f"rate limited: retry in {retry_after}s"
+        # Bypass SlackApiError.__init__: it str-formats the response into its
+        # message, which can itself raise for unusual bodies (e.g. bytes) —
+        # unacceptable inside the error path.
+        Exception.__init__(self, self.rate_limit_message)
+
+    def __str__(self) -> str:
+        return self.rate_limit_message
 
     @classmethod
     def from_slack_error(cls, error: SlackApiError) -> "ClacksRateLimited | None":
         """Translate a SlackApiError into ClacksRateLimited.
 
-        Returns None when the error is not a rate limit. Detection accepts
-        either HTTP status 429 or the "ratelimited" error payload.
+        Returns the error itself when it is already a ClacksRateLimited, and
+        None when it is not a rate limit. Detection accepts either HTTP status
+        429 or the "ratelimited" error payload.
         """
+        if isinstance(error, ClacksRateLimited):
+            return error
         response = error.response
         if response is None:
             return None
         if getattr(response, "status_code", None) == 429:
-            return cls(retry_after=rate_limit_retry_after(error))
+            return cls(retry_after=rate_limit_retry_after(error), response=response)
         try:
             error_code = response.get("error")
         except (AttributeError, TypeError, ValueError):
             return None
         if error_code == "ratelimited":
-            return cls(retry_after=rate_limit_retry_after(error))
+            return cls(retry_after=rate_limit_retry_after(error), response=response)
         return None

--- a/src/slack_clacks/exceptions.py
+++ b/src/slack_clacks/exceptions.py
@@ -13,7 +13,9 @@ def rate_limit_retry_after(error: SlackApiError) -> int | None:
     """Extract the Retry-After value (seconds) from a SlackApiError.
 
     Reads response headers case-insensitively and tolerates missing or
-    malformed values by returning None.
+    malformed values by returning None. Non-positive values are treated as
+    missing: a 0 hint would otherwise drive zero-delay hot retries in
+    call_with_backoff and useless "retry in 0s" advice from the CLI.
     """
     headers: Any = getattr(error.response, "headers", None)
     if not headers:
@@ -25,7 +27,7 @@ def rate_limit_retry_after(error: SlackApiError) -> int | None:
             seconds = int(str(value).strip())
         except ValueError:
             continue
-        if seconds < 0:
+        if seconds <= 0:
             continue
         return seconds
     return None

--- a/src/slack_clacks/exceptions.py
+++ b/src/slack_clacks/exceptions.py
@@ -1,0 +1,60 @@
+"""
+Client-wide exceptions for clacks.
+"""
+
+from typing import Any
+
+from slack_sdk.errors import SlackApiError
+
+RATE_LIMIT_EXIT_CODE = 75  # EX_TEMPFAIL: caller should wait and retry.
+
+
+def rate_limit_retry_after(error: SlackApiError) -> int | None:
+    """Extract the Retry-After value (seconds) from a SlackApiError.
+
+    Reads response headers case-insensitively and tolerates missing or
+    malformed values by returning None.
+    """
+    headers: Any = getattr(error.response, "headers", None)
+    if not headers:
+        return None
+    for key, value in headers.items():
+        if str(key).lower() != "retry-after":
+            continue
+        try:
+            return int(str(value).strip())
+        except ValueError:
+            continue
+    return None
+
+
+class ClacksRateLimited(Exception):
+    """Raised when Slack rate limits a request (HTTP 429 / "ratelimited")."""
+
+    def __init__(self, retry_after: int | None = None) -> None:
+        self.retry_after = retry_after
+        if retry_after is None:
+            message = "rate limited: retry later"
+        else:
+            message = f"rate limited: retry in {retry_after}s"
+        super().__init__(message)
+
+    @classmethod
+    def from_slack_error(cls, error: SlackApiError) -> "ClacksRateLimited | None":
+        """Translate a SlackApiError into ClacksRateLimited.
+
+        Returns None when the error is not a rate limit. Detection accepts
+        either HTTP status 429 or the "ratelimited" error payload.
+        """
+        response = error.response
+        if response is None:
+            return None
+        if getattr(response, "status_code", None) == 429:
+            return cls(retry_after=rate_limit_retry_after(error))
+        try:
+            error_code = response.get("error")
+        except (AttributeError, TypeError):
+            return None
+        if error_code == "ratelimited":
+            return cls(retry_after=rate_limit_retry_after(error))
+        return None

--- a/src/slack_clacks/messaging/operations.py
+++ b/src/slack_clacks/messaging/operations.py
@@ -12,6 +12,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from sqlalchemy.orm import Session
 
+from slack_clacks.exceptions import ClacksRateLimited
 from slack_clacks.messaging.exceptions import (
     ClacksChannelNotFoundError,
     ClacksUserNotFoundError,
@@ -83,6 +84,8 @@ def resolve_channel_id(
             if not cursor:
                 break
     except SlackApiError as e:
+        if ClacksRateLimited.from_slack_error(e) is not None:
+            raise
         raise ClacksChannelNotFoundError(channel_identifier) from e
 
     raise ClacksChannelNotFoundError(channel_identifier)
@@ -132,6 +135,8 @@ def resolve_user_id(
             if not cursor:
                 break
     except SlackApiError as e:
+        if ClacksRateLimited.from_slack_error(e) is not None:
+            raise
         raise ClacksUserNotFoundError(user_identifier) from e
 
     raise ClacksUserNotFoundError(user_identifier)
@@ -232,7 +237,9 @@ def open_dm_channel(client: WebClient, user_id: str) -> str | None:
     try:
         response = client.conversations_open(users=[user_id])
         return response["channel"]["id"]
-    except SlackApiError:
+    except SlackApiError as e:
+        if ClacksRateLimited.from_slack_error(e) is not None:
+            raise
         return None
 
 

--- a/src/slack_clacks/messaging/operations.py
+++ b/src/slack_clacks/messaging/operations.py
@@ -25,20 +25,29 @@ def call_with_backoff(
     base_delay: float = 1.0,
     **kwargs: Any,
 ) -> Any:
-    """Call a Slack API function with exponential backoff on rate limit."""
+    """Call a Slack API function with exponential backoff on rate limit.
+
+    Rate limits are detected via ``ClacksRateLimited.from_slack_error``, so
+    both typed ClacksRateLimited errors and raw SlackApiError 429s (whatever
+    their payload shape) are retried; the response is never dereferenced
+    directly. The Retry-After hint is used as the delay when available,
+    falling back to exponential backoff otherwise. Non-rate-limit errors and
+    the final rate-limited attempt re-raise.
+    """
     for attempt in range(max_retries):
         try:
             return func(**kwargs)
         except SlackApiError as e:
-            if e.response.get("error") == "ratelimited":
-                if attempt == max_retries - 1:
-                    raise
-                # Get retry-after header or use exponential backoff
-                retry_after = int(e.response.headers.get("Retry-After", 0))
-                delay = max(retry_after, base_delay * (2**attempt))
-                time.sleep(delay)
-            else:
+            rate_limited = ClacksRateLimited.from_slack_error(e)
+            if rate_limited is None:
                 raise
+            if attempt == max_retries - 1:
+                raise
+            if rate_limited.retry_after is not None:
+                delay = float(rate_limited.retry_after)
+            else:
+                delay = base_delay * (2**attempt)
+            time.sleep(delay)
     return None  # Should never reach here
 
 

--- a/src/slack_clacks/messaging/operations.py
+++ b/src/slack_clacks/messaging/operations.py
@@ -52,6 +52,7 @@ def resolve_channel_id(
     Resolve channel identifier to channel ID.
     Accepts channel ID (C..., D..., G...), channel name (#general or general), or alias.
     Returns channel ID or raises ClacksChannelNotFoundError if not found.
+    Rate-limited lookups re-raise the original SlackApiError instead.
 
     Resolution order:
     1. Check if already a Slack channel ID (C..., D..., G...)
@@ -101,6 +102,7 @@ def resolve_user_id(
     Resolve user identifier to user ID.
     Accepts user ID (U...), username (@username or username), email, or alias.
     Returns user ID or raises ClacksUserNotFoundError if not found.
+    Rate-limited lookups re-raise the original SlackApiError instead.
 
     Resolution order:
     1. Check if already a Slack user ID (U...)

--- a/src/slack_clacks/messaging/operations.py
+++ b/src/slack_clacks/messaging/operations.py
@@ -232,7 +232,8 @@ def parse_timestamp(value: str) -> str:
 def open_dm_channel(client: WebClient, user_id: str) -> str | None:
     """
     Open a DM channel with a user.
-    Returns channel ID or None if failed.
+    Returns channel ID, or None if the open failed.
+    Re-raises rate-limited SlackApiError instead of returning None.
     """
     try:
         response = client.conversations_open(users=[user_id])

--- a/src/slack_clacks/skill/content.py
+++ b/src/slack_clacks/skill/content.py
@@ -299,6 +299,8 @@ uvx --from slack-clacks clacks config info
 
 All commands output JSON to stdout.
 The `listen` command outputs NDJSON (one JSON object per line).
+Exit code 75 with stderr `rate limited: retry in Ns` means Slack rate limited
+the call: wait N seconds, then re-run the same command.
 """
 
 OPENAI_YAML = """\

--- a/src/slack_clacks/skill/content.py
+++ b/src/slack_clacks/skill/content.py
@@ -299,8 +299,9 @@ uvx --from slack-clacks clacks config info
 
 All commands output JSON to stdout.
 The `listen` command outputs NDJSON (one JSON object per line).
-Exit code 75 with stderr `rate limited: retry in Ns` means Slack rate limited
-the call: wait N seconds, then re-run the same command.
+Exit code 75 means Slack rate limited the call: stderr is `rate limited: retry in Ns`
+(wait N seconds) or `rate limited: retry later` (no delay given; wait ~30s). Then
+re-run the same command.
 """
 
 OPENAI_YAML = """\

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,86 @@
+"""Tests for ClacksWebClient's rate-limit translation at the api_call funnel."""
+
+import unittest
+from unittest.mock import patch
+
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.base_client import BaseClient
+from slack_sdk.web.slack_response import SlackResponse
+
+from slack_clacks.auth.client import ClacksWebClient, create_client
+from slack_clacks.auth.constants import MODE_CLACKS, MODE_COOKIE
+from slack_clacks.exceptions import ClacksRateLimited
+
+
+def rate_limited_slack_error() -> SlackApiError:
+    """A real SlackApiError shaped like a live-captured 429."""
+    response = SlackResponse(
+        client=None,
+        http_verb="POST",
+        api_url="https://slack.com/api/search.messages",
+        req_args={},
+        data={"ok": False, "error": "ratelimited"},
+        headers={"Retry-After": "30"},
+        status_code=429,
+    )
+    return SlackApiError("The request to the Slack API failed.", response)
+
+
+class TestClacksWebClientRateLimitTranslation(unittest.TestCase):
+    def test_method_helper_raises_clacks_rate_limited_on_429(self):
+        """SDK method helpers funnel through api_call, so a 429 anywhere
+        surfaces as ClacksRateLimited with the Retry-After hint attached."""
+        original = rate_limited_slack_error()
+        client = ClacksWebClient(token="xoxp-test")
+
+        with patch.object(BaseClient, "api_call", side_effect=original):
+            with self.assertRaises(ClacksRateLimited) as ctx:
+                client.conversations_history(channel="C123456")
+
+        self.assertEqual(ctx.exception.retry_after, 30)
+        self.assertIs(ctx.exception.__cause__, original)
+
+    def test_clacks_rate_limited_is_a_slack_api_error(self):
+        """Existing `except SlackApiError` sites must keep catching it."""
+        self.assertIsInstance(ClacksRateLimited(30), SlackApiError)
+
+    def test_non_rate_limit_error_passes_through_unchanged(self):
+        response = SlackResponse(
+            client=None,
+            http_verb="POST",
+            api_url="https://slack.com/api/conversations.history",
+            req_args={},
+            data={"ok": False, "error": "channel_not_found"},
+            headers={},
+            status_code=200,
+        )
+        original = SlackApiError("The request to the Slack API failed.", response)
+        client = ClacksWebClient(token="xoxp-test")
+
+        with patch.object(BaseClient, "api_call", side_effect=original):
+            with self.assertRaises(SlackApiError) as ctx:
+                client.conversations_history(channel="C123456")
+
+        self.assertIs(ctx.exception, original)
+        self.assertNotIsInstance(ctx.exception, ClacksRateLimited)
+
+    def test_successful_call_passes_through(self):
+        sentinel = object()
+        client = ClacksWebClient(token="xoxp-test")
+
+        with patch.object(BaseClient, "api_call", return_value=sentinel):
+            self.assertIs(client.api_call("auth.test"), sentinel)
+
+
+class TestCreateClientType(unittest.TestCase):
+    def test_default_mode_returns_clacks_web_client(self):
+        self.assertIsInstance(create_client("xoxp-test", MODE_CLACKS), ClacksWebClient)
+
+    def test_cookie_mode_returns_clacks_web_client(self):
+        self.assertIsInstance(
+            create_client("xoxc-test|d-cookie", MODE_COOKIE), ClacksWebClient
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,25 +2,28 @@ import unittest
 from typing import Any
 
 from slack_sdk.errors import SlackApiError
+from slack_sdk.web.slack_response import SlackResponse
 
 from slack_clacks.exceptions import ClacksRateLimited, rate_limit_retry_after
 
 
-class StubSlackResponse:
-    """Minimal stand-in for slack_sdk's SlackResponse in SlackApiError."""
-
-    def __init__(
-        self,
-        status_code: int,
-        data: dict[str, Any] | None = None,
-        headers: dict[str, str] | None = None,
-    ) -> None:
-        self.status_code = status_code
-        self.data = data or {}
-        self.headers = headers or {}
-
-    def get(self, key: str, default: Any = None) -> Any:
-        return self.data.get(key, default)
+def slack_response(
+    status_code: int,
+    data: dict[str, Any] | bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> SlackResponse:
+    """Build a real SlackResponse offline (no client, no HTTP)."""
+    if data is None:
+        data = {"ok": False, "error": "ratelimited"}
+    return SlackResponse(
+        client=None,
+        http_verb="POST",
+        api_url="https://slack.com/api/conversations.list",
+        req_args={},
+        data=data,
+        headers=headers or {},
+        status_code=status_code,
+    )
 
 
 def rate_limited_error(
@@ -28,9 +31,7 @@ def rate_limited_error(
     data: dict[str, Any] | None = None,
     headers: dict[str, str] | None = None,
 ) -> SlackApiError:
-    if data is None:
-        data = {"ok": False, "error": "ratelimited"}
-    response = StubSlackResponse(status_code, data=data, headers=headers)
+    response = slack_response(status_code, data=data, headers=headers)
     return SlackApiError("The request to the Slack API failed.", response)
 
 
@@ -49,6 +50,10 @@ class TestRateLimitRetryAfter(unittest.TestCase):
 
     def test_malformed_header_value(self):
         error = rate_limited_error(headers={"Retry-After": "soon"})
+        self.assertIsNone(rate_limit_retry_after(error))
+
+    def test_negative_header_value(self):
+        error = rate_limited_error(headers={"Retry-After": "-5"})
         self.assertIsNone(rate_limit_retry_after(error))
 
     def test_malformed_value_falls_back_to_valid_duplicate(self):
@@ -89,7 +94,18 @@ class TestClacksRateLimitedFromSlackError(unittest.TestCase):
         )
         self.assertIsNone(ClacksRateLimited.from_slack_error(error))
 
+    def test_bytes_response_data_returns_none(self):
+        # SlackResponse.get raises ValueError on bytes data; from_slack_error
+        # must tolerate it instead of crashing. SlackApiError's constructor
+        # str()s the response (which also rejects bytes), so attach the bytes
+        # response after construction.
+        error = SlackApiError("boom", None)
+        error.response = slack_response(200, data=b"not json")
+        self.assertIsNone(ClacksRateLimited.from_slack_error(error))
+
     def test_error_without_response_returns_none(self):
+        # Deliberately degenerate case: SlackApiError carrying no response at
+        # all, which a real SlackResponse cannot represent.
         error = SlackApiError("boom", None)
         self.assertIsNone(ClacksRateLimited.from_slack_error(error))
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,98 @@
+import unittest
+from typing import Any
+
+from slack_sdk.errors import SlackApiError
+
+from slack_clacks.exceptions import ClacksRateLimited, rate_limit_retry_after
+
+
+class StubSlackResponse:
+    """Minimal stand-in for slack_sdk's SlackResponse in SlackApiError."""
+
+    def __init__(
+        self,
+        status_code: int,
+        data: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.data = data or {}
+        self.headers = headers or {}
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self.data.get(key, default)
+
+
+def rate_limited_error(
+    status_code: int = 429,
+    data: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+) -> SlackApiError:
+    if data is None:
+        data = {"ok": False, "error": "ratelimited"}
+    response = StubSlackResponse(status_code, data=data, headers=headers)
+    return SlackApiError("The request to the Slack API failed.", response)
+
+
+class TestRateLimitRetryAfter(unittest.TestCase):
+    def test_capitalized_header(self):
+        error = rate_limited_error(headers={"Retry-After": "30"})
+        self.assertEqual(rate_limit_retry_after(error), 30)
+
+    def test_lowercase_header(self):
+        error = rate_limited_error(headers={"retry-after": "12"})
+        self.assertEqual(rate_limit_retry_after(error), 12)
+
+    def test_missing_header(self):
+        error = rate_limited_error(headers={"x-slack-failure": "ratelimited"})
+        self.assertIsNone(rate_limit_retry_after(error))
+
+    def test_malformed_header_value(self):
+        error = rate_limited_error(headers={"Retry-After": "soon"})
+        self.assertIsNone(rate_limit_retry_after(error))
+
+    def test_malformed_value_falls_back_to_valid_duplicate(self):
+        error = rate_limited_error(headers={"Retry-After": "soon", "retry-after": "30"})
+        self.assertEqual(rate_limit_retry_after(error), 30)
+
+
+class TestClacksRateLimitedFromSlackError(unittest.TestCase):
+    def test_status_429_with_retry_after(self):
+        error = rate_limited_error(headers={"Retry-After": "30"})
+        translated = ClacksRateLimited.from_slack_error(error)
+        self.assertIsNotNone(translated)
+        self.assertEqual(translated.retry_after, 30)
+        self.assertEqual(str(translated), "rate limited: retry in 30s")
+
+    def test_ratelimited_error_without_429_status(self):
+        error = rate_limited_error(status_code=200, headers={"retry-after": "5"})
+        translated = ClacksRateLimited.from_slack_error(error)
+        self.assertIsNotNone(translated)
+        self.assertEqual(translated.retry_after, 5)
+
+    def test_429_without_ratelimited_payload(self):
+        error = rate_limited_error(data={"ok": False}, headers={"Retry-After": "9"})
+        translated = ClacksRateLimited.from_slack_error(error)
+        self.assertIsNotNone(translated)
+        self.assertEqual(translated.retry_after, 9)
+
+    def test_missing_retry_after_header(self):
+        error = rate_limited_error()
+        translated = ClacksRateLimited.from_slack_error(error)
+        self.assertIsNotNone(translated)
+        self.assertIsNone(translated.retry_after)
+        self.assertEqual(str(translated), "rate limited: retry later")
+
+    def test_non_rate_limited_error_returns_none(self):
+        error = rate_limited_error(
+            status_code=200, data={"ok": False, "error": "channel_not_found"}
+        )
+        self.assertIsNone(ClacksRateLimited.from_slack_error(error))
+
+    def test_error_without_response_returns_none(self):
+        error = SlackApiError("boom", None)
+        self.assertIsNone(ClacksRateLimited.from_slack_error(error))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -109,6 +109,17 @@ class TestClacksRateLimitedFromSlackError(unittest.TestCase):
         error = SlackApiError("boom", None)
         self.assertIsNone(ClacksRateLimited.from_slack_error(error))
 
+    def test_already_translated_error_returns_itself(self):
+        # Idempotency: the client raises ClacksRateLimited at the source, and
+        # downstream seams may translate again; identity must be preserved.
+        rate_limited = ClacksRateLimited(30)
+        self.assertIs(ClacksRateLimited.from_slack_error(rate_limited), rate_limited)
+
+    def test_translated_error_carries_response(self):
+        error = rate_limited_error(headers={"Retry-After": "30"})
+        translated = ClacksRateLimited.from_slack_error(error)
+        self.assertIs(translated.response, error.response)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -56,6 +56,12 @@ class TestRateLimitRetryAfter(unittest.TestCase):
         error = rate_limited_error(headers={"Retry-After": "-5"})
         self.assertIsNone(rate_limit_retry_after(error))
 
+    def test_zero_header_value(self):
+        # 0 is treated as missing: honoring it would mean zero-delay hot
+        # retries in call_with_backoff and "retry in 0s" advice at the CLI.
+        error = rate_limited_error(headers={"Retry-After": "0"})
+        self.assertIsNone(rate_limit_retry_after(error))
+
     def test_malformed_value_falls_back_to_valid_duplicate(self):
         error = rate_limited_error(headers={"Retry-After": "soon", "retry-after": "30"})
         self.assertEqual(rate_limit_retry_after(error), 30)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,9 +3,14 @@ import io
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
+from slack_sdk.errors import SlackApiError
+from slack_sdk.web.slack_response import SlackResponse
+
 from slack_clacks import main
+from slack_clacks.exceptions import RATE_LIMIT_EXIT_CODE
 from slack_clacks.skill.status import SkillInstallStatus
 
 
@@ -100,3 +105,76 @@ class TestMainSkillWarnings(unittest.TestCase):
 
         self.assertEqual(int(exc.exception.code), 0)
         mock_status.assert_not_called()
+
+
+def slack_api_error(
+    status_code: int,
+    data: dict[str, Any],
+    headers: dict[str, str] | None = None,
+) -> SlackApiError:
+    """Build a SlackApiError carrying a real SlackResponse, fully offline."""
+    response = SlackResponse(
+        client=None,
+        http_verb="POST",
+        api_url="https://slack.com/api/chat.postMessage",
+        req_args={},
+        data=data,
+        headers=headers or {},
+        status_code=status_code,
+    )
+    return SlackApiError("The request to the Slack API failed.", response)
+
+
+class TestMainRateLimitSeam(unittest.TestCase):
+    def run_main_with_error(self, error: Exception) -> tuple[int, str, str]:
+        """Run main() with a stub handler that raises error.
+
+        Returns (exit code, stdout, stderr). Exceptions other than SystemExit
+        propagate to the caller.
+        """
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        def handler(_: argparse.Namespace) -> None:
+            raise error
+
+        parser = MagicMock()
+        parser.parse_args.return_value = argparse.Namespace(func=handler)
+
+        with (
+            redirect_stdout(stdout),
+            redirect_stderr(stderr),
+            patch("slack_clacks.generate_cli", return_value=parser),
+            patch("slack_clacks.check_skill_install_status", return_value=None),
+        ):
+            try:
+                main(["send"])
+            except SystemExit as exc:
+                return _system_exit_code(exc), stdout.getvalue(), stderr.getvalue()
+
+        return 0, stdout.getvalue(), stderr.getvalue()
+
+    def test_rate_limited_error_exits_75_with_stderr_message(self):
+        error = slack_api_error(
+            status_code=429,
+            data={"ok": False, "error": "ratelimited"},
+            headers={"Retry-After": "30"},
+        )
+
+        code, stdout, stderr = self.run_main_with_error(error)
+
+        self.assertEqual(code, 75)
+        self.assertEqual(code, RATE_LIMIT_EXIT_CODE)
+        self.assertEqual(stderr, "rate limited: retry in 30s\n")
+        self.assertEqual(stdout, "")
+
+    def test_non_rate_limited_slack_error_propagates(self):
+        error = slack_api_error(
+            status_code=200,
+            data={"ok": False, "error": "channel_not_found"},
+        )
+
+        with self.assertRaises(SlackApiError) as ctx:
+            self.run_main_with_error(error)
+
+        self.assertIs(ctx.exception, error)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ from slack_sdk.errors import SlackApiError
 from slack_sdk.web.slack_response import SlackResponse
 
 from slack_clacks import main
-from slack_clacks.exceptions import RATE_LIMIT_EXIT_CODE
+from slack_clacks.exceptions import RATE_LIMIT_EXIT_CODE, ClacksRateLimited
 from slack_clacks.skill.status import SkillInstallStatus
 
 
@@ -178,3 +178,12 @@ class TestMainRateLimitSeam(unittest.TestCase):
             self.run_main_with_error(error)
 
         self.assertIs(ctx.exception, error)
+
+    def test_clacks_rate_limited_from_client_exits_75(self):
+        """The production path: ClacksWebClient raises ClacksRateLimited
+        directly; the seam must handle it identically to a raw 429."""
+        code, stdout, stderr = self.run_main_with_error(ClacksRateLimited(30))
+
+        self.assertEqual(code, RATE_LIMIT_EXIT_CODE)
+        self.assertEqual(stderr, "rate limited: retry in 30s\n")
+        self.assertEqual(stdout, "")

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web.slack_response import SlackResponse
 
+from slack_clacks.exceptions import ClacksRateLimited
 from slack_clacks.messaging.operations import (
     call_with_backoff,
     open_dm_channel,
@@ -410,6 +411,60 @@ def rate_limited_slack_error(api_url: str) -> SlackApiError:
         status_code=429,
     )
     return SlackApiError("The request to the Slack API failed.", response)
+
+
+class TestCallWithBackoffTypedRateLimit(unittest.TestCase):
+    @patch("slack_clacks.messaging.operations.time.sleep")
+    def test_typed_rate_limit_retries_then_succeeds(self, mock_sleep):
+        """A ClacksRateLimited from a real 429 is retried like a raw error."""
+        error = ClacksRateLimited.from_slack_error(
+            rate_limited_slack_error("https://slack.com/api/conversations.history")
+        )
+        self.assertIsNotNone(error)
+
+        call_count = 0
+
+        def mock_func(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise error
+            return {"messages": []}
+
+        result = call_with_backoff(mock_func, max_retries=5, base_delay=0.01)
+        self.assertEqual(call_count, 3)
+        self.assertEqual(result, {"messages": []})
+
+    @patch("slack_clacks.messaging.operations.time.sleep")
+    def test_typed_rate_limit_raises_after_max_retries(self, mock_sleep):
+        """The typed exception propagates once retries are exhausted."""
+        error = ClacksRateLimited.from_slack_error(
+            rate_limited_slack_error("https://slack.com/api/conversations.history")
+        )
+        self.assertIsNotNone(error)
+
+        def mock_func(**kwargs):
+            raise error
+
+        with self.assertRaises(ClacksRateLimited) as ctx:
+            call_with_backoff(mock_func, max_retries=2, base_delay=0.01)
+
+        self.assertIs(ctx.exception, error)
+
+
+class TestResolveChannelIdTypedRateLimit(unittest.TestCase):
+    def test_typed_rate_limit_propagates(self):
+        """A ClacksRateLimited from the client (production path) propagates."""
+        error = ClacksRateLimited.from_slack_error(
+            rate_limited_slack_error("https://slack.com/api/conversations.list")
+        )
+        client = MagicMock()
+        client.conversations_list.side_effect = error
+
+        with self.assertRaises(ClacksRateLimited) as ctx:
+            resolve_channel_id(client, "general")
+
+        self.assertIs(ctx.exception, error)
 
 
 class TestResolveUserIdRateLimit(unittest.TestCase):

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -434,6 +434,8 @@ class TestCallWithBackoffTypedRateLimit(unittest.TestCase):
         result = call_with_backoff(mock_func, max_retries=5, base_delay=0.01)
         self.assertEqual(call_count, 3)
         self.assertEqual(result, {"messages": []})
+        # The server's Retry-After hint, not exponential backoff, sets the delay.
+        mock_sleep.assert_called_with(30.0)
 
     @patch("slack_clacks.messaging.operations.time.sleep")
     def test_typed_rate_limit_raises_after_max_retries(self, mock_sleep):

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -4,11 +4,13 @@ from datetime import timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from slack_sdk.errors import SlackApiError
+from slack_sdk.web.slack_response import SlackResponse
 
 from slack_clacks.messaging.operations import (
     call_with_backoff,
     parse_schedule_time,
     parse_timestamp,
+    resolve_channel_id,
     resolve_message_timestamp,
 )
 
@@ -369,6 +371,29 @@ class TestCallWithBackoff(unittest.TestCase):
 
         with self.assertRaises(SlackApiError):
             call_with_backoff(mock_func, max_retries=2, base_delay=0.01)
+
+
+class TestResolveChannelIdRateLimit(unittest.TestCase):
+    def test_rate_limited_lookup_propagates_slack_api_error(self):
+        """A 429 during name resolution must not become channel-not-found."""
+        response = SlackResponse(
+            client=None,
+            http_verb="POST",
+            api_url="https://slack.com/api/conversations.list",
+            req_args={},
+            data={"ok": False, "error": "ratelimited"},
+            headers={"Retry-After": "30"},
+            status_code=429,
+        )
+        error = SlackApiError("The request to the Slack API failed.", response)
+
+        client = MagicMock()
+        client.conversations_list.side_effect = error
+
+        with self.assertRaises(SlackApiError) as ctx:
+            resolve_channel_id(client, "general")
+
+        self.assertIs(ctx.exception, error)
 
 
 if __name__ == "__main__":

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -8,10 +8,12 @@ from slack_sdk.web.slack_response import SlackResponse
 
 from slack_clacks.messaging.operations import (
     call_with_backoff,
+    open_dm_channel,
     parse_schedule_time,
     parse_timestamp,
     resolve_channel_id,
     resolve_message_timestamp,
+    resolve_user_id,
 )
 
 
@@ -394,6 +396,64 @@ class TestResolveChannelIdRateLimit(unittest.TestCase):
             resolve_channel_id(client, "general")
 
         self.assertIs(ctx.exception, error)
+
+
+def rate_limited_slack_error(api_url: str) -> SlackApiError:
+    """A real SlackApiError shaped like a live-captured 429."""
+    response = SlackResponse(
+        client=None,
+        http_verb="POST",
+        api_url=api_url,
+        req_args={},
+        data={"ok": False, "error": "ratelimited"},
+        headers={"Retry-After": "30"},
+        status_code=429,
+    )
+    return SlackApiError("The request to the Slack API failed.", response)
+
+
+class TestResolveUserIdRateLimit(unittest.TestCase):
+    def test_rate_limited_lookup_propagates_slack_api_error(self):
+        """A 429 during name resolution must not become user-not-found."""
+        error = rate_limited_slack_error("https://slack.com/api/users.list")
+        client = MagicMock()
+        client.users_list.side_effect = error
+
+        with self.assertRaises(SlackApiError) as ctx:
+            resolve_user_id(client, "@nosuchuser")
+
+        self.assertIs(ctx.exception, error)
+
+
+class TestOpenDmChannelRateLimit(unittest.TestCase):
+    def test_rate_limited_open_propagates_slack_api_error(self):
+        """A 429 opening a DM must raise, not silently return None."""
+        error = rate_limited_slack_error("https://slack.com/api/conversations.open")
+        client = MagicMock()
+        client.conversations_open.side_effect = error
+
+        with self.assertRaises(SlackApiError) as ctx:
+            open_dm_channel(client, "U123456")
+
+        self.assertIs(ctx.exception, error)
+
+    def test_non_rate_limit_error_still_returns_none(self):
+        """Ordinary API failures keep the None contract."""
+        response = SlackResponse(
+            client=None,
+            http_verb="POST",
+            api_url="https://slack.com/api/conversations.open",
+            req_args={},
+            data={"ok": False, "error": "user_not_found"},
+            headers={},
+            status_code=200,
+        )
+        client = MagicMock()
+        client.conversations_open.side_effect = SlackApiError(
+            "The request to the Slack API failed.", response
+        )
+
+        self.assertIsNone(open_dm_channel(client, "U123456"))
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.12.2"
+version = "0.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.12.3"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Closes #91.

## Problem

clacks had no rate-limit handling at the CLI surface: a Slack 429 surfaced as a raw `SlackApiError` traceback (exit 1), indistinguishable from a permanent failure. Worse, the name-resolution paths wrapped every `SlackApiError` into "channel/user not found", so an agent hitting a 429 during `send -u @alice` was told the user doesn't exist.

## Design

clacks does not retry or sleep at the CLI level. It fails fast and tells the caller exactly how long to wait — the agent owns the wait:

- **Exit code 75** (`EX_TEMPFAIL`, the established "transient — retry later" sysexits convention; exit codes are 8-bit, so 429 itself is impossible) with a single stderr line: `rate limited: retry in Ns` (from the 429's `Retry-After` header) or `rate limited: retry later` (no usable hint). stdout stays clean JSON.
- The skill documents the agent contract in two lines, keyed on the exit code.

## Architecture

- `ClacksRateLimited` (new `src/slack_clacks/exceptions.py`) — **subclasses `SlackApiError`**, so every existing `except SlackApiError` site keeps working. Carries `retry_after`; `from_slack_error` translates (status 429 OR `"ratelimited"` payload; idempotent; case-insensitive string `Retry-After` parsing tolerant of malformed/duplicate/non-positive values). Its `__init__` deliberately bypasses the parent's (which str-formats the response into the message and can itself raise on unusual bodies).
- `ClacksWebClient` (in `auth/client.py`) — overrides `api_call`, the funnel all SDK method helpers route through, raising `ClacksRateLimited from` the original. `create_client` returns it for both auth modes, so the typed error originates at the source for every command.
- `main()` seam — converts rate limits (typed or raw, defense in depth) to the stderr line + exit 75; everything else propagates unchanged.
- Rate-limit re-raise guards in `resolve_channel_id`/`resolve_user_id`/`open_dm_channel` and the auth login flows, so 429s are never laundered into "not found"/generic errors before reaching the seam.
- `call_with_backoff` (internal retry for `listen`/`recent`) now detects via the same predicate and prefers the server's `Retry-After` as its delay, with exponential fallback; non-positive hints are treated as missing (a literal 0 previously meant zero-delay hot retries).

## Review process

Implemented via two cycles of iterated adversarial review (4 → 2 → 1 reviewers per round, fixing between rounds). Cycle 1 converged on the seam design; the architecture was then refactored to raise from the client (typed exception at the source) and re-reviewed from scratch. Highlights of what review caught and fixed along the way: the seam initially untested (exit code mutable to 1 with a green suite); resolver rate-limit masking; a missing `ValueError` in the defensive header parsing (proven reachable); the backoff predicate diverging from the new detection; the `Retry-After: 0` hot-retry regression (caught independently by both round-2 reviewers); auth login flows re-typing errors before the seam.

Grounded throughout in a live-captured 429 anatomy (status 429, `{"ok": false, "error": "ratelimited"}`, string `Retry-After` under both casings) rather than documentation.

## Verification

- Live, twice (before and after the client refactor): hammering `search` on a Tier-2 endpoint against a dev workspace trips a real 429 → `clacks search ...` exits **75**, stderr `rate limited: retry in 30s`, stdout empty.
- 173 tests (37 new): the seam contract (exit code, exact stderr, clean stdout, non-rate-limit propagation), the client funnel translation with cause chaining, typed errors through backoff and resolvers, header-parsing edge cases (casings, duplicates, malformed, negative, zero, bytes bodies), `create_client` types, idempotency. Key tests were mutation-verified during review (each deliberate regression fails a specific test).
- All checks green: `ruff check`, `ruff format --check`, `mypy src/`, unittest.

## Known residue (recorded, deliberate)

- `files_upload_v2`'s file-bytes upload leg bypasses `api_call` and raises `SlackRequestError` — outside this contract (documented in the client docstring).
- `get_recent_activity` keeps its documented per-channel retry-then-skip behavior; `auth status` keeps its best-effort metadata swallows.
- Version 0.13.0 — the contract change is the headline reliability improvement for agents driving clacks.