### PR TITLE
files: add delete subcommand wrapping files.delete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.13.0"
+version = "0.14.0"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/files/cli.py
+++ b/src/slack_clacks/files/cli.py
@@ -143,7 +143,8 @@ def handle_delete(args: argparse.Namespace) -> None:
 
 def generate_files_cli() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Upload, download, list, inspect, and delete files"
+        prog="clacks files",
+        description="Upload, download, list, inspect, and delete files",
     )
     parser.set_defaults(func=lambda _: parser.print_help())
 

--- a/src/slack_clacks/files/cli.py
+++ b/src/slack_clacks/files/cli.py
@@ -17,6 +17,7 @@ from slack_clacks.configuration.database import (
     resolve_context,
 )
 from slack_clacks.files.operations import (
+    delete_file,
     download_file_to_path,
     download_file_to_stdout,
     extract_file_id_from_permalink,
@@ -119,9 +120,30 @@ def handle_info(args: argparse.Namespace) -> None:
         json.dump(result, sys.stdout)
 
 
+def handle_delete(args: argparse.Namespace) -> None:
+    ensure_db_updated(config_dir=args.config_dir)
+    with get_session(args.config_dir) as session:
+        context = resolve_context(session, args.context)
+
+        scopes = get_scopes_for_mode(context.app_type)
+        validate("files:write", scopes, raise_on_error=True)
+
+        client = create_client(context.access_token, context.app_type)
+
+        # Resolve file ID
+        if args.file_id:
+            file_id = args.file_id
+        else:
+            file_id = extract_file_id_from_permalink(args.permalink)
+
+        result = delete_file(client, file_id)
+        with args.outfile as ofp:
+            json.dump(result, ofp)
+
+
 def generate_files_cli() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Upload, download, list, and inspect files"
+        description="Upload, download, list, inspect, and delete files"
     )
     parser.set_defaults(func=lambda _: parser.print_help())
 
@@ -219,6 +241,39 @@ def generate_files_cli() -> argparse.ArgumentParser:
         help="Slack file ID (e.g., F2147483862)",
     )
     info_parser.set_defaults(func=handle_info)
+
+    # --- delete ---
+    del_parser = subparsers.add_parser(
+        "delete", help="Delete a file from Slack (your own files only)"
+    )
+    del_parser.add_argument(
+        "-D",
+        "--config-dir",
+        type=str,
+        default=None,
+        help="Configuration directory",
+    )
+    add_context_argument(del_parser)
+    del_id_group = del_parser.add_mutually_exclusive_group(required=True)
+    del_id_group.add_argument(
+        "-i",
+        "--file-id",
+        type=str,
+        help="Slack file ID (e.g., F2147483862)",
+    )
+    del_id_group.add_argument(
+        "--permalink",
+        type=str,
+        help="Slack file permalink URL",
+    )
+    del_parser.add_argument(
+        "-o",
+        "--outfile",
+        type=argparse.FileType("a"),
+        default=sys.stdout,
+        help="Output file for JSON results (default: stdout)",
+    )
+    del_parser.set_defaults(func=handle_delete)
 
     # --- upload ---
     upload_parser = generate_upload_parser()

--- a/src/slack_clacks/files/operations.py
+++ b/src/slack_clacks/files/operations.py
@@ -20,6 +20,12 @@ def get_file_info(client: WebClient, file_id: str) -> dict | bytes:
     return response.data
 
 
+def delete_file(client: WebClient, file_id: str) -> dict | bytes:
+    """Delete a file from Slack."""
+    response = client.files_delete(file=file_id)
+    return response.data
+
+
 def list_files(
     client: WebClient,
     channel: str | None = None,

--- a/src/slack_clacks/skill/content.py
+++ b/src/slack_clacks/skill/content.py
@@ -230,7 +230,10 @@ Private upload (returns permalink, not shared to any channel):
 echo "print('hello')" | uvx --from slack-clacks clacks files upload -t python
 ```
 
-Delete a file (your own files only):
+## Deleting Files
+
+Delete a file (your own files only). Note: deleting a message does NOT delete
+its attached file — the file persists in workspace storage until deleted here:
 ```bash
 uvx --from slack-clacks clacks files delete -i F2147483862
 ```

--- a/src/slack_clacks/skill/content.py
+++ b/src/slack_clacks/skill/content.py
@@ -230,6 +230,11 @@ Private upload (returns permalink, not shared to any channel):
 echo "print('hello')" | uvx --from slack-clacks clacks files upload -t python
 ```
 
+Delete a file (your own files only):
+```bash
+uvx --from slack-clacks clacks files delete -i F2147483862
+```
+
 ## Listening for Messages
 
 Listen for new messages in a channel (outputs NDJSON, one message per line):

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Problem

`clacks files` had upload/download/list/info but no delete — removing a file required a raw API call. The gap is sharper than it looks: deleting a message does NOT delete its attached file (a file is an independent object with share records; `chat.delete` removes only the share), so upload-then-tidy workflows silently accumulate orphaned files that count against workspace storage and are visible only via `files list`.

## Change

- `clacks files delete (-i FILE_ID | --permalink URL)` wrapping Slack's `files.delete`, mirroring `download`'s identifier handling (shared `extract_file_id_from_permalink`), with `files:write` scope validation (as `upload`), standard `-D`/`-C`/`-o` wiring, and the inherited rate-limit contract (429 → exit 75 via `ClacksWebClient`).
- Fixed the files subparser `prog`: `clacks files delete --help` previously printed `usage: clacks delete ...` — the usage line of the unrelated top-level message-delete command. Explicit `prog="clacks files"` repairs all five subcommands' help and error prefixes.
- Skill content: new `## Deleting Files` section documenting the command and the message-deletion-doesn't-delete-files semantics.
- Version 0.14.0.

No unit tests by repo convention (thin API passthrough; mock-mirror tests rejected); verified live instead.

## Verification

Live against clacks-dev (self-cleaning): private upload → `files info` confirms → `files delete` returns `{"ok": true}` → `files info` now fails with `file_deleted`. Permalink extraction verified on the canonical permalink form. All help/usage/error-prefix renders checked after the `prog` fix, including that top-level `clacks delete` is unaffected.

Review: one implementer, then 4 independent adversarial reviewers (all findings NIT/MINOR; the `prog` collision and skill mis-sectioning fixed, wording/edge-case parallels with siblings deliberately kept), then a single final reviewer — clean.

Known residue: `extract_file_id_from_permalink` cannot parse real `url_private` (`files-pri/T...-F...`) URLs — pre-existing, affects `download` identically, proven by execution during review, filed as #94 and queued next.

All checks pass: `ruff check`, `ruff format --check`, `mypy src/`, 173 unittests.