### PR TITLE
Fix extract_file_id_from_permalink for real files-pri (url_private) URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "slack-clacks"
-version = "0.14.0"
+version = "0.14.1"
 description = "the default mode of degenerate communication."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/slack_clacks/files/cli.py
+++ b/src/slack_clacks/files/cli.py
@@ -170,7 +170,7 @@ def generate_files_cli() -> argparse.ArgumentParser:
     id_group.add_argument(
         "--permalink",
         type=str,
-        help="Slack file permalink URL",
+        help="Slack file URL: permalink or url_private/url_private_download",
     )
     dl_parser.add_argument(
         "-w",
@@ -265,7 +265,7 @@ def generate_files_cli() -> argparse.ArgumentParser:
     del_id_group.add_argument(
         "--permalink",
         type=str,
-        help="Slack file permalink URL",
+        help="Slack file URL: permalink or url_private/url_private_download",
     )
     del_parser.add_argument(
         "-o",

--- a/src/slack_clacks/files/operations.py
+++ b/src/slack_clacks/files/operations.py
@@ -6,6 +6,7 @@ import re
 import sys
 import urllib.request
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from slack_sdk import WebClient
 
@@ -45,13 +46,16 @@ def list_files(
 
 def extract_file_id_from_permalink(url: str) -> str:
     """
-    Extract a Slack file ID from a permalink URL.
+    Extract a Slack file ID from a file URL.
 
-    Supports formats like:
-    - https://workspace.slack.com/files/U.../F2147483862/filename.txt
-    - https://files.slack.com/files-pri/T.../F2147483862/filename.txt
+    Supports the URL shapes Slack actually emits:
+    - permalink: https://<workspace>.slack.com/files/U.../F2147483862/filename.txt
+    - url_private / url_private_download (team and file IDs hyphen-joined):
+      https://files.slack.com/files-pri/T024BE7LD-F2147483862/filename.txt
+      (url_private_download inserts a /download/ segment; query params allowed)
     """
-    match = re.search(r"/(F[A-Z0-9]+)", url)
+    path = urlsplit(url).path
+    match = re.search(r"(?:^|[/-])(F[A-Z0-9]{8,})(?=/|$)", path)
     if not match:
         raise ValueError(f"Could not extract file ID from URL: {url}")
     return match.group(1)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -18,8 +18,28 @@ class TestExtractFileIdFromPermalink(unittest.TestCase):
         url = "https://myteam.slack.com/files/U123ABC/F2147483862/report.pdf"
         self.assertEqual(extract_file_id_from_permalink(url), "F2147483862")
 
-    def test_files_pri_url(self):
-        url = "https://files.slack.com/files-pri/T0001/F9876ABCDE/image.png"
+    def test_url_private_hyphen_joined(self):
+        url = "https://files.slack.com/files-pri/T024BE7LD-F9876ABCDE/image.png"
+        self.assertEqual(extract_file_id_from_permalink(url), "F9876ABCDE")
+
+    def test_url_private_download(self):
+        url = (
+            "https://files.slack.com/files-pri/T024BE7LD-F9876ABCDE/download/image.png"
+        )
+        self.assertEqual(extract_file_id_from_permalink(url), "F9876ABCDE")
+
+    def test_url_with_query_params(self):
+        url = (
+            "https://files.slack.com/files-pri/"
+            "T024BE7LD-F9876ABCDE/report.pdf?t=xoxe-F0000000000"
+        )
+        self.assertEqual(extract_file_id_from_permalink(url), "F9876ABCDE")
+
+    def test_filename_with_id_like_token(self):
+        url = (
+            "https://files.slack.com/files-pri/"
+            "T024BE7LD-F9876ABCDE/DRAFT-FINAL2026X.txt"
+        )
         self.assertEqual(extract_file_id_from_permalink(url), "F9876ABCDE")
 
     def test_invalid_url_raises(self):
@@ -29,6 +49,10 @@ class TestExtractFileIdFromPermalink(unittest.TestCase):
     def test_no_f_prefix_raises(self):
         with self.assertRaises(ValueError):
             extract_file_id_from_permalink("https://slack.com/files/U123/not-a-file")
+
+    def test_short_f_segment_raises(self):
+        with self.assertRaises(ValueError):
+            extract_file_id_from_permalink("https://example.com/F12/file.txt")
 
 
 class TestBuildDownloadHeaders(unittest.TestCase):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -54,6 +54,23 @@ class TestExtractFileIdFromPermalink(unittest.TestCase):
         with self.assertRaises(ValueError):
             extract_file_id_from_permalink("https://example.com/F12/file.txt")
 
+    def test_minimum_length_file_id(self):
+        # F + exactly 8 chars: the legacy boundary from issue #94. Pins the
+        # {8,} floor — a tightening to {9,} must fail here.
+        url = "https://files.slack.com/files-pri/T024BE7LD-F024BERPE/x.png"
+        self.assertEqual(extract_file_id_from_permalink(url), "F024BERPE")
+
+    def test_path_ending_at_id(self):
+        # No filename segment: exercises the $ branch of the lookahead.
+        url = "https://files.slack.com/files-pri/T024BE7LD-F9876ABCDE?t=xoxe-1"
+        self.assertEqual(extract_file_id_from_permalink(url), "F9876ABCDE")
+
+    def test_glued_token_rejected_by_lookahead(self):
+        # An ID-like token glued to trailing text, with no real ID anywhere:
+        # only the (?=/|$) lookahead rejects this (leftmost match cannot).
+        with self.assertRaises(ValueError):
+            extract_file_id_from_permalink("https://example.com/DRAFT-FINAL2026X.txt")
+
 
 class TestBuildDownloadHeaders(unittest.TestCase):
     def test_normal_mode(self):

--- a/uv.lock
+++ b/uv.lock
@@ -299,7 +299,7 @@ wheels = [
 
 [[package]]
 name = "slack-clacks"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Closes #94.

## Problem

`extract_file_id_from_permalink` claimed to support `files-pri` URLs but encoded a slash-separated form Slack never produces. Real `url_private`/`url_private_download` URLs hyphen-join the team and file IDs (`files-pri/T09TLGVE0US-F0B9BSUM8F7/...` — captured live from the API, not assumed), and the old regex's `/F` requirement made them raise `ValueError`. The old tests passed against the fictional URL shape. Affected `files download --permalink` and `files delete --permalink`.

## Fix

```python
path = urlsplit(url).path
match = re.search(r"(?:^|[/-])(F[A-Z0-9]{8,})(?=/|$)", path)
```

- `urlsplit().path` restricts matching to the path — query tokens (`?t=xoxe-...`), fragments, and hostnames can no longer false-positive (the old regex matched F-tokens in hostnames).
- `(?:^|[/-])` accepts both the canonical `/files/U.../F.../name` and the hyphen-joined `files-pri/T...-F.../name` forms; the legacy slash-separated form still parses, so nothing regresses.
- `{8,}` floors the ID length at the legacy boundary (the issue's own `F024BERPE` is F + exactly 8).
- `(?=/|$)` requires the ID to terminate a path segment, rejecting ID-like tokens glued to filenames — and fixes a second latent old bug (leftmost uppercase segments like `/FOOBAR/` previously won over the real ID).

`--permalink` help on download/delete now states that `url_private`/`url_private_download` are accepted. Version 0.14.1 (bug fix).

## Tests (7 net new; mutation-verified)

Real-shape fixtures for all three URL forms plus query params, the legacy-boundary ID, path-ending-at-ID, and glued-token rejection. Review ran three suite-surviving mutants against the original test set (`{9,}` quantifier, lookahead deleted, lookahead weakened to `(?=/)`); the hardening commit adds one test per mutant, and the final reviewer re-ran all three confirming each now dies from exactly its designated test.

## Verification

Live against clacks-dev twice (implementer, then an independent integration pass): upload → `download --permalink` with all three real URL shapes (byte-exact content) → `delete --permalink` via both permalink and url_private → `file_deleted` confirmed. Self-cleaning.

Review: one implementer → 4 adversarial reviewers (all NIT/MINOR; consensus test-hardening applied, declines documented) → single final reviewer (clean).

## Known residue (deliberate)

Thumbnail URLs (`files-tmb/T...-F...-<hash>/...`) still raise: the trailing `-hash` defeats the segment-termination lookahead, and loosening it to `(?=[/-]|$)` would weaken glued-token rejection — a trade that deserves its own change if thumbnail pasting ever matters.

All checks pass: `ruff check`, `ruff format --check`, `mypy src/`, 180 unittests.